### PR TITLE
Add global list `processingMessages` to retain messages being processed

### DIFF
--- a/lib/services/backend/action_handler.dart
+++ b/lib/services/backend/action_handler.dart
@@ -23,6 +23,26 @@ class ActionHandler extends GetxService {
   final List<String> handledNewMessages = [];
   CancelToken? latestCancelToken;
 
+  @override
+  void onInit() {
+    super.onInit();
+    processPendingMessages();
+  }
+
+  Future<void> processPendingMessages() async {
+    for (var item in Queue.processingMessages) {
+      if (item is IncomingItem) {
+        await handleNewMessage(item.chat, item.message, item.tempGuid);
+      } else if (item is OutgoingItem) {
+        if (item.type == QueueType.sendMessage) {
+          await sendMessage(item.chat, item.message, item.selected, item.reaction);
+        } else if (item.type == QueueType.sendAttachment) {
+          await sendAttachment(item.chat, item.message, item.customArgs?['audio'] ?? false);
+        }
+      }
+    }
+  }
+
   /// Checks if a GUID has been handled.
   /// After each check, before returning, trim the list of GUIDs to the last 100.
   bool shouldNotifyForNewMessageGuid(String guid) {

--- a/lib/services/backend/queue/incoming_queue.dart
+++ b/lib/services/backend/queue/incoming_queue.dart
@@ -16,6 +16,9 @@ class IncomingQueue extends Queue {
     assert(_ is IncomingItem);
     final item = _ as IncomingItem;
 
+    // Add message to the processingMessages list
+    processingMessages.add(item);
+
     switch (item.type) {
       case QueueType.newMessage:
         await ah.handleNewMessage(item.chat, item.message, item.tempGuid);
@@ -27,5 +30,8 @@ class IncomingQueue extends Queue {
         Logger.info("Unhandled queue event: ${item.type.name}");
         break;
     }
+
+    // Remove message from the processingMessages list
+    processingMessages.remove(item);
   }
 }

--- a/lib/services/backend/queue/outgoing_queue.dart
+++ b/lib/services/backend/queue/outgoing_queue.dart
@@ -57,6 +57,9 @@ class OutgoingQueue extends Queue {
     assert(_ is OutgoingItem);
     final item = _ as OutgoingItem;
 
+    // Add message to the processingMessages list
+    processingMessages.add(item);
+
     switch (item.type) {
       case QueueType.sendMessage:
         await handleSend(() => ah.sendMessage(item.chat, item.message, item.selected, item.reaction), item.chat);
@@ -68,5 +71,8 @@ class OutgoingQueue extends Queue {
         Logger.info("Unhandled queue event: ${item.type.name}");
         break;
     }
+
+    // Remove message from the processingMessages list
+    processingMessages.remove(item);
   }
 }

--- a/lib/services/backend/queue/queue_impl.dart
+++ b/lib/services/backend/queue/queue_impl.dart
@@ -10,6 +10,7 @@ import 'package:get/get.dart';
 abstract class Queue extends GetxService {
   bool isProcessing = false;
   List<QueueItem> items = [];
+  static List<QueueItem> processingMessages = [];
 
   Future<void> queue(QueueItem item) async {
     final returned = await prepItem(item);
@@ -48,6 +49,7 @@ abstract class Queue extends GetxService {
 
     isProcessing = true;
     QueueItem queued = items.removeAt(0);
+    processingMessages.add(queued);
 
     try {
       await handleQueueItem(queued).catchError((err) async {
@@ -69,6 +71,7 @@ abstract class Queue extends GetxService {
       queued.completer?.completeError(ex);
     }
 
+    processingMessages.remove(queued);
     await processNextItem();
   }
 


### PR DESCRIPTION
* Add `processingMessages` list to `lib/services/backend/queue/queue_impl.dart`
* Add messages to `processingMessages` list when they are being processed in `lib/services/backend/queue/queue_impl.dart`, `lib/services/backend/queue/incoming_queue.dart`, and `lib/services/backend/queue/outgoing_queue.dart`
* Remove messages from `processingMessages` list once they are confirmed finished in `lib/services/backend/queue/queue_impl.dart`, `lib/services/backend/queue/incoming_queue.dart`, and `lib/services/backend/queue/outgoing_queue.dart`
* Check `processingMessages` list on startup and process any messages still in the list in `lib/services/backend/action_handler.dart`