### PR TITLE
Add and remove members from ongoing call

### DIFF
--- a/lib/app/layouts/conversation_details/dialogs/add_participant.dart
+++ b/lib/app/layouts/conversation_details/dialogs/add_participant.dart
@@ -8,7 +8,7 @@ import 'package:slugify/slugify.dart';
 import 'package:tuple/tuple.dart';
 import 'package:bluebubbles/services/network/backend_service.dart';
 
-void showAddParticipant(BuildContext context, Chat chat) {
+void showAddParticipant(BuildContext context, Chat chat, {bool isOngoingCall = false}) {
   final TextEditingController participantController = TextEditingController();
   showDialog(
     context: context,
@@ -130,7 +130,9 @@ void showAddParticipant(BuildContext context, Chat chat) {
                     );
                   }
               );
-              final response = await backend.chatParticipant(ParticipantOp.Add, chat, participantController.text);
+              final response = isOngoingCall
+                  ? await pushService.addMember(participantController.text)
+                  : await backend.chatParticipant(ParticipantOp.Add, chat, participantController.text);
               if (response) {
                 Get.back();
                 Get.back();

--- a/lib/app/layouts/conversation_details/widgets/chat_info.dart
+++ b/lib/app/layouts/conversation_details/widgets/chat_info.dart
@@ -17,6 +17,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:universal_io/io.dart';
 import 'package:bluebubbles/src/rust/api/api.dart' as api;
+import 'package:bluebubbles/app/layouts/conversation_details/dialogs/add_participant.dart';
 
 class ChatInfo extends StatefulWidget {
   const ChatInfo({super.key, required this.chat, required this.ftSupportedParticipants});
@@ -133,6 +134,19 @@ class _ChatInfoState extends OptimizedState<ChatInfo> {
       } else {
         showSnackbar("Error", "Failed to delete group photo!");
       }
+    }
+  }
+
+  void addParticipantToCall() async {
+    showAddParticipant(context, chat, isOngoingCall: true);
+  }
+
+  void removeParticipantFromCall(String participant) async {
+    final response = await pushService.removeMember(participant);
+    if (response) {
+      showSnackbar("Notice", "Removed $participant successfully!");
+    } else {
+      showSnackbar("Error", "Failed to remove $participant!");
     }
   }
 
@@ -349,6 +363,60 @@ class _ChatInfoState extends OptimizedState<ChatInfo> {
             padding: const EdgeInsets.only(left: 15.0, bottom: 5.0),
             child: Text("${chat.participants.length} ${iOS ? "OTHER MEMBERS" : "OTHER PEOPLE"}",
                 style: context.theme.textTheme.bodyMedium!.copyWith(color: context.theme.colorScheme.outline)),
+          ),
+        if (chat.isGroup)
+          Padding(
+            padding: const EdgeInsets.only(left: 15.0, bottom: 5.0),
+            child: Text("ONGOING CALL",
+                style: context.theme.textTheme.bodyMedium!.copyWith(color: context.theme.colorScheme.outline)),
+          ),
+        if (chat.isGroup)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 5.0),
+            child: Material(
+              color: Colors.transparent,
+              child: ListTile(
+                mouseCursor: MouseCursor.defer,
+                onTap: () async {
+                  addParticipantToCall();
+                },
+                title: Text("Add participant to call", style: context.theme.textTheme.bodyLarge!),
+                trailing: Icon(Icons.add, color: context.theme.colorScheme.onBackground),
+              ),
+            ),
+          ),
+        if (chat.isGroup)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 5.0),
+            child: Material(
+              color: Colors.transparent,
+              child: ListTile(
+                mouseCursor: MouseCursor.defer,
+                onTap: () async {
+                  final participant = await showDialog<String>(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return SimpleDialog(
+                        title: Text("Select participant to remove"),
+                        children: chat.participants.map((participant) {
+                          return SimpleDialogOption(
+                            onPressed: () {
+                              Navigator.pop(context, participant.address);
+                            },
+                            child: Text(participant.address),
+                          );
+                        }).toList(),
+                      );
+                    },
+                  );
+                  if (participant != null) {
+                    removeParticipantFromCall(participant);
+                  }
+                },
+                title: Text("Remove participant from call", style: context.theme.textTheme.bodyLarge!),
+                trailing: Icon(Icons.remove, color: context.theme.colorScheme.onBackground),
+              ),
+            ),
           ),
       ]),
     );

--- a/lib/app/layouts/facetime/facetime.dart
+++ b/lib/app/layouts/facetime/facetime.dart
@@ -114,6 +114,19 @@ class _FaceTimePanelState extends OptimizedState<FaceTimePanel> {
     );
   }
 
+  void addParticipantToCall() async {
+    showAddParticipant(context, chat, isOngoingCall: true);
+  }
+
+  void removeParticipantFromCall(String participant) async {
+    final response = await pushService.removeMember(participant);
+    if (response) {
+      showSnackbar("Notice", "Removed $participant successfully!");
+    } else {
+      showSnackbar("Error", "Failed to remove $participant!");
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Obx(() => SettingsScaffold(
@@ -161,6 +174,60 @@ class _FaceTimePanelState extends OptimizedState<FaceTimePanel> {
                   padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 30),
                   child: Text("No Calls! Users can add you to FaceTime calls. They'll show up here, where you can join them.", style: context.textTheme.bodyMedium!,),
                 ),
+                if (chat.isGroup)
+                  Padding(
+                    padding: const EdgeInsets.only(left: 15.0, bottom: 5.0),
+                    child: Text("ONGOING CALL",
+                        style: context.theme.textTheme.bodyMedium!.copyWith(color: context.theme.colorScheme.outline)),
+                  ),
+                if (chat.isGroup)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 5.0),
+                    child: Material(
+                      color: Colors.transparent,
+                      child: ListTile(
+                        mouseCursor: MouseCursor.defer,
+                        onTap: () async {
+                          addParticipantToCall();
+                        },
+                        title: Text("Add participant to call", style: context.theme.textTheme.bodyLarge!),
+                        trailing: Icon(Icons.add, color: context.theme.colorScheme.onBackground),
+                      ),
+                    ),
+                  ),
+                if (chat.isGroup)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 5.0),
+                    child: Material(
+                      color: Colors.transparent,
+                      child: ListTile(
+                        mouseCursor: MouseCursor.defer,
+                        onTap: () async {
+                          final participant = await showDialog<String>(
+                            context: context,
+                            builder: (BuildContext context) {
+                              return SimpleDialog(
+                                title: Text("Select participant to remove"),
+                                children: chat.participants.map((participant) {
+                                  return SimpleDialogOption(
+                                    onPressed: () {
+                                      Navigator.pop(context, participant.address);
+                                    },
+                                    child: Text(participant.address),
+                                  );
+                                }).toList(),
+                              );
+                            },
+                          );
+                          if (participant != null) {
+                            removeParticipantFromCall(participant);
+                          }
+                        },
+                        title: Text("Remove participant from call", style: context.theme.textTheme.bodyLarge!),
+                        trailing: Icon(Icons.remove, color: context.theme.colorScheme.onBackground),
+                      ),
+                    ),
+                  ),
               ]),
           )
         ])


### PR DESCRIPTION
Add functionality to invite and remove participants from an ongoing call.

* **lib/app/layouts/conversation_details/dialogs/add_participant.dart**
  - Add `isOngoingCall` parameter to `showAddParticipant` function.
  - Update `showAddParticipant` to use `pushService.addMember` for ongoing calls.
* **lib/app/layouts/conversation_details/widgets/chat_info.dart**
  - Add `addParticipantToCall` and `removeParticipantFromCall` functions.
  - Add UI elements to add and remove participants from an ongoing call.
* **lib/app/layouts/facetime/facetime.dart**
  - Add `addParticipantToCall` and `removeParticipantFromCall` functions.
  - Add UI elements to add and remove participants from an ongoing call.
  
  https://discord.com/channels/1130633272595066880/1270130354224758986/1335360967696977971

