### PR TITLE
Add failed message indicator in chat inbox

### DIFF
--- a/lib/app/layouts/conversation_list/widgets/tile/cupertino_conversation_tile.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/cupertino_conversation_tile.dart
@@ -300,7 +300,16 @@ class _CupertinoTrailingState extends CustomState<CupertinoTrailing, void, Conve
                           ? context.theme.colorScheme.onBubble(context, controller.chat.isIMessage)
                           : context.theme.colorScheme.outline,
                       size: 12,
-                    ))
+                    )),
+              if (cachedLatestMessage?.error ?? 0 > 0)
+                Padding(
+                  padding: const EdgeInsets.only(top: 5.0),
+                  child: Icon(
+                    CupertinoIcons.clear_circled_solid,
+                    color: context.theme.colorScheme.error,
+                    size: 12,
+                  ),
+                ),
             ],
           ),
         ],

--- a/lib/app/layouts/conversation_list/widgets/tile/material_conversation_tile.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/material_conversation_tile.dart
@@ -314,6 +314,14 @@ class _MaterialTrailingState extends CustomState<MaterialTrailing, void, Convers
                         color: controller.shouldHighlight.value || unread ? context.theme.colorScheme.primary : context.theme.colorScheme.outline,
                         size: 15,
                       )),
+                if ((cachedLatestMessage?.error ?? 0) > 0)
+                  const SizedBox(width: 5),
+                if ((cachedLatestMessage?.error ?? 0) > 0)
+                  Icon(
+                    Icons.error,
+                    color: context.theme.colorScheme.error,
+                    size: 15,
+                  ),
               ],
             ),
           ],

--- a/lib/app/layouts/conversation_view/widgets/message/timestamp/delivered_indicator.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/timestamp/delivered_indicator.dart
@@ -87,6 +87,8 @@ class _DeliveredIndicatorState extends CustomState<DeliveredIndicator, void, Mes
         return buildTwoPiece("Scheduled", buildDate(message.dateScheduled));
       }
       return buildTwoPiece("Sent", buildDate(message.dateCreated));
+    } else if (message.error > 0) {
+      return buildTwoPiece("Failed", buildDate(message.dateCreated));
     }
 
     return [];


### PR DESCRIPTION
Fixes #62

Add logic to display a red x or similar indicator for failed messages in the chat inbox.

* **Cupertino Conversation Tile**
  - Add logic to `CupertinoTrailing` to display a red x for failed messages.
  - Update the `CupertinoTrailing` class to include the new logic.

* **Material Conversation Tile**
  - Add logic to `MaterialTrailing` to display a red x for failed messages.
  - Update the `MaterialTrailing` class to include the new logic.

* **Delivered Indicator**
  - Update the `DeliveredIndicator` class to handle failed messages.
  - Add logic to display a red x for failed messages.

