### PR TITLE
opt-in to MTE async mode

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -68,6 +68,7 @@
     <application
         android:name="${applicationName}"
         android:allowBackup="false"
+        android:memtagMode="async"
         android:appCategory="social"
         android:debuggable="false"
         android:extractNativeLibs="true"


### PR DESCRIPTION
currently only benefits GrapheneOS users on Pixel 8 and 9 who don't turn on MTE for all apps or Molly manually. hopefully will be extended to all Pixel users and then more devices