### PR TITLE
Fix hardware keystore crash on MediaTek devices (AES wrapped import)

### DIFF
--- a/rust/src/keystore.rs
+++ b/rust/src/keystore.rs
@@ -148,6 +148,17 @@ pub fn supports_import(keystore: &NativeKeystoreHolder) -> Result<bool, Keystore
     keystore.destroy_key("test:ec")?;
     keystore.destroy_key("test:import")?;
 
+    // Test AES 256 wrapped key import (fails on some MediaTek TEEs)
+    keystore.destroy_key("test:aes")?;
+    let aes_key: [u8; 32] = rand::random();
+    keystore.import_key("test:aes", KeyType::Aes(256), &aes_key, KeystoreAccessRules {
+        block_modes: vec![EncryptMode::Gcm],
+        can_encrypt: true,
+        can_decrypt: true,
+        ..Default::default()
+    })?;
+    keystore.destroy_key("test:aes")?;
+
     Ok(true)
 }
 


### PR DESCRIPTION
## Summary

- Add AES 256 GCM key import test to `supports_import()` so devices that fail AES wrapped key import correctly fall back to `SoftwareKeystore`
- Fixes crash during onboarding activation: `KeyStoreException: Failed to import wrapped key. Keystore error code: -59`

## Problem

I was unable to select "use this device" when registering Open Bubbles on my Bluefox NX1 (mediatek) beginning in late January 2026. adb logcat revealed this was a hardware keystore issue.

The hardware keystore capability test in `supports_import()` (`rust/src/keystore.rs`) tests RSA 1024 and EC P384 key imports, but never tests AES 256 wrapped key import. On some MediaTek TEEs, RSA and EC imports succeed but AES wrapped key import fails with `UNSUPPORTED_MIN_MAC_LENGTH` / error code -59.

This causes a runtime crash when `AesKeystoreKey::ensure("ids:identity-storage-key:openbubbles", 256, ...)` is called during activation, because the device was incorrectly classified as hardware-compatible.

### Affected device

- **BlueFox NX1** — MediaTek MT6769V/CB (Helio G85), Android 15, SDK 35
- Likely affects other MediaTek devices where the TEE supports RSA/EC but not AES wrapped key import

## Fix

Add an AES 256 key import test after the existing RSA and EC tests in `supports_import()`, using the same `KeyType::Aes(256)` and `EncryptMode::Gcm` access rules as the real `ids:identity-storage-key`. If this test fails, the device correctly falls back to `SoftwareKeystore`.

```rust
// Test AES 256 wrapped key import (fails on some MediaTek TEEs)
keystore.destroy_key("test:aes")?;
let aes_key: [u8; 32] = rand::random();
keystore.import_key("test:aes", KeyType::Aes(256), &aes_key, KeystoreAccessRules {
    block_modes: vec![EncryptMode::Gcm],
    can_encrypt: true,
    can_decrypt: true,
    ..Default::default()
})?;
keystore.destroy_key("test:aes")?;
```

## Test plan

- [x] Built patched APK and installed on affected BlueFox NX1 device
- [x] Cleared app data to reset keystore detection
- [x] Confirmed via `adb logcat` that `keystore2` reports `Error::Km(r#UNSUPPORTED_MIN_MAC_LENGTH)` during the new AES test
- [x] Confirmed app falls back to `SoftwareKeystore` (logs show `keystore:software:encryptor`)
- [x] Confirmed no `KeyStoreException` crash — app runs normally
- [ ] Verify no regression on devices where hardware keystore works correctly (AES test should pass transparently)

(Can't test the last one, but I confirmed the app now works properly on my NX1 - compiled with dummy fairplay certs).