### PR TITLE
Fix intermittent black screen on startup

### DIFF
--- a/lib/app/layouts/startup/failure_to_start.dart
+++ b/lib/app/layouts/startup/failure_to_start.dart
@@ -9,6 +9,9 @@ class FailureToStart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final errorText = e?.toString() ?? 'Unknown error';
+    final stackText = s?.toString() ?? '';
+
     return MaterialApp(
       title: 'OpenBubbles',
       home: AnnotatedRegion<SystemUiOverlayStyle>(
@@ -20,32 +23,58 @@ class FailureToStart extends StatelessWidget {
         ),
         child: Scaffold(
           backgroundColor: Colors.black,
-          body: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              mainAxisSize: MainAxisSize.max,
-              children: [
-                Center(
-                  child: Text(
-                    otherTitle ?? "Whoops, looks like we messed up. Unfortunately you will need to reinstall the app, sorry for the inconvenience :(",
-                    style: const TextStyle(color: Colors.white, fontSize: 30),
-                    textAlign: TextAlign.center,
+          body: SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                mainAxisSize: MainAxisSize.max,
+                children: [
+                  const SizedBox(height: 40),
+                  const Icon(Icons.error_outline, color: Colors.redAccent, size: 64),
+                  const SizedBox(height: 16),
+                  Center(
+                    child: Text(
+                      otherTitle ?? "Whoops, something went wrong during startup.",
+                      style: const TextStyle(color: Colors.white, fontSize: 24),
+                      textAlign: TextAlign.center,
+                    ),
                   ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 20.0),
-                  child: Center(
-                    child: Text("Error: ${e.toString()}", style: const TextStyle(color: Colors.white, fontSize: 10)),
+                  const SizedBox(height: 8),
+                  Center(
+                    child: Text(
+                      errorText.contains('timed out')
+                          ? "A startup task timed out. Please restart the app. If this keeps happening, try reinstalling."
+                          : "Please restart the app. If this keeps happening, you may need to reinstall.",
+                      style: const TextStyle(color: Colors.white70, fontSize: 14),
+                      textAlign: TextAlign.center,
+                    ),
                   ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 20.0),
-                  child: Center(
-                    child: Text("Stacktrace: ${s.toString()}", style: const TextStyle(color: Colors.white, fontSize: 10)),
+                  const SizedBox(height: 24),
+                  OutlinedButton.icon(
+                    onPressed: () {
+                      Clipboard.setData(ClipboardData(text: "Error: $errorText\n\nStacktrace: $stackText"));
+                    },
+                    icon: const Icon(Icons.copy, color: Colors.white70, size: 16),
+                    label: const Text("Copy Error Details", style: TextStyle(color: Colors.white70)),
+                    style: OutlinedButton.styleFrom(side: const BorderSide(color: Colors.white38)),
                   ),
-                )
-              ],
+                  const SizedBox(height: 24),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8.0),
+                    child: Center(
+                      child: Text("Error: $errorText", style: const TextStyle(color: Colors.white60, fontSize: 10)),
+                    ),
+                  ),
+                  if (stackText.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 16.0),
+                      child: Center(
+                        child: Text("Stacktrace: $stackText", style: const TextStyle(color: Colors.white38, fontSize: 10)),
+                      ),
+                    ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/database/database.dart
+++ b/lib/database/database.dart
@@ -93,30 +93,102 @@ class Database {
     await initComplete.future;
   }
 
-  static Future<void> _initDatabaseMobile({bool? storeOpenStatus}) async {
+  /// Timeout for database open/attach operations to prevent indefinite blocking.
+  static const Duration _dbOpenTimeout = Duration(seconds: 10);
+
+  /// Maximum number of retry attempts for database initialization.
+  static const int _maxRetries = 3;
+
+  static bool _isDbLockError(String errorMsg) {
+    final lower = errorMsg.toLowerCase();
+    return lower.contains("another store is still open using the same path") ||
+        lower.contains("lock") ||
+        lower.contains("already in use") ||
+        lower.contains("busy");
+  }
+
+  static bool _isDbCorruptionError(String errorMsg) {
+    final lower = errorMsg.toLowerCase();
+    return lower.contains("corrupt") ||
+        lower.contains("invalid database") ||
+        lower.contains("schema version mismatch") ||
+        lower.contains("storageexception");
+  }
+
+  static Future<void> _initDatabaseMobile({bool? storeOpenStatus, int retryCount = 0}) async {
+    final Stopwatch sw = Stopwatch()..start();
     Directory objectBoxDirectory = Directory(join(fs.appDocDir.path, 'objectbox'));
     final isStoreOpen = storeOpenStatus ?? Store.isOpen(objectBoxDirectory.path);
 
     try {
       if (isStoreOpen) {
-        Logger.info("Attempting to attach to an existing ObjectBox store...");
-        store = Store.attach(getObjectBoxModel(), objectBoxDirectory.path);
-        Logger.info("Successfully attached to an existing ObjectBox store");
+        Logger.info("Attempting to attach to an existing ObjectBox store (attempt ${retryCount + 1})...", tag: "DB-Init");
+        store = await Future(() => Store.attach(getObjectBoxModel(), objectBoxDirectory.path))
+            .timeout(_dbOpenTimeout, onTimeout: () {
+          throw TimeoutException("Store.attach() timed out after ${_dbOpenTimeout.inSeconds}s — another process may hold the lock");
+        });
+        Logger.info("Successfully attached to an existing ObjectBox store in ${sw.elapsedMilliseconds}ms", tag: "DB-Init");
       } else {
-        Logger.info("Opening new ObjectBox store from path: ${objectBoxDirectory.path}");
-        store = await openStore(directory: objectBoxDirectory.path, maxDBSizeInKB: 5 * 1024 * 1024);
+        Logger.info("Opening new ObjectBox store from path: ${objectBoxDirectory.path}", tag: "DB-Init");
+        store = await openStore(directory: objectBoxDirectory.path, maxDBSizeInKB: 5 * 1024 * 1024)
+            .timeout(_dbOpenTimeout, onTimeout: () {
+          throw TimeoutException("openStore() timed out after ${_dbOpenTimeout.inSeconds}s — database may be locked");
+        });
+        Logger.info("Opened ObjectBox store in ${sw.elapsedMilliseconds}ms", tag: "DB-Init");
+      }
+    } on TimeoutException catch (e) {
+      sw.stop();
+      Logger.error("Database open timed out after ${sw.elapsedMilliseconds}ms", error: e, tag: "DB-Init");
+      if (retryCount < _maxRetries) {
+        Logger.info("Retrying database init (attempt ${retryCount + 2}/${_maxRetries + 1})...", tag: "DB-Init");
+        await Future.delayed(Duration(milliseconds: 500 * (retryCount + 1)));
+        await _initDatabaseMobile(storeOpenStatus: storeOpenStatus, retryCount: retryCount + 1);
+      } else {
+        Logger.error("All database open attempts exhausted. The database may be locked by another process.", tag: "DB-Init");
+        rethrow;
       }
     } catch (e, s) {
-      Logger.error("Failed to open ObjectBox store!", error: e, trace: s);
+      sw.stop();
+      Logger.error("Failed to open ObjectBox store after ${sw.elapsedMilliseconds}ms!", error: e, trace: s, tag: "DB-Init");
+      final errorMsg = e.toString();
 
-      if (e.toString().contains("another store is still open using the same path")) {
-        Logger.info("Retrying to attach to an existing ObjectBox store");
-        await _initDatabaseMobile(storeOpenStatus: true);
+      if (_isDbCorruptionError(errorMsg)) {
+        Logger.error("Database appears corrupted. Backing up and recreating...", tag: "DB-Init");
+        try {
+          if (objectBoxDirectory.existsSync()) {
+            final backupDir = Directory("${objectBoxDirectory.path}.backup");
+            if (backupDir.existsSync()) {
+              backupDir.deleteSync(recursive: true);
+            }
+            objectBoxDirectory.renameSync(backupDir.path);
+            Logger.info("Corrupted database backed up to ${backupDir.path}", tag: "DB-Init");
+          }
+          objectBoxDirectory.createSync(recursive: true);
+          store = await openStore(directory: objectBoxDirectory.path, maxDBSizeInKB: 5 * 1024 * 1024)
+              .timeout(_dbOpenTimeout, onTimeout: () {
+            throw TimeoutException("openStore() timed out during corruption recovery");
+          });
+          Logger.info("Successfully recreated ObjectBox store after corruption recovery. Old data backed up.", tag: "DB-Init");
+          return;
+        } catch (recoveryError, recoveryTrace) {
+          Logger.error("Database corruption recovery failed!", error: recoveryError, trace: recoveryTrace, tag: "DB-Init");
+          rethrow;
+        }
+      }
+
+      if (_isDbLockError(errorMsg) && retryCount < _maxRetries) {
+        Logger.info("Database locked. Retrying with attach (attempt ${retryCount + 2}/${_maxRetries + 1})...", tag: "DB-Init");
+        await Future.delayed(Duration(milliseconds: 500 * (retryCount + 1)));
+        await _initDatabaseMobile(storeOpenStatus: true, retryCount: retryCount + 1);
+      } else if (retryCount >= _maxRetries) {
+        Logger.error("All database open attempts exhausted.", tag: "DB-Init");
+        rethrow;
       }
     }
   }
 
   static Future<void> _initDatabaseDesktop() async {
+    final Stopwatch sw = Stopwatch()..start();
     Directory objectBoxDirectory = Directory(join(fs.appDocDir.path, 'objectbox'));
 
     try {
@@ -124,24 +196,54 @@ class Database {
       if (ss.prefs.getBool('use-custom-path') == true && ss.prefs.getString('custom-path') != null) {
         Directory oldCustom = Directory(join(ss.prefs.getString('custom-path')!, 'objectbox'));
         if (oldCustom.existsSync()) {
-          Logger.info("Detected prior use of custom path option. Migrating...");
+          Logger.info("Detected prior use of custom path option. Migrating...", tag: "DB-Init");
           fs.copyDirectory(oldCustom, objectBoxDirectory);
         }
         await ss.prefs.remove('use-custom-path');
         await ss.prefs.remove('custom-path');
       }
 
-      Logger.info("Opening ObjectBox store from path: ${objectBoxDirectory.path}");
-      store = await openStore(directory: objectBoxDirectory.path);
+      Logger.info("Opening ObjectBox store from path: ${objectBoxDirectory.path}", tag: "DB-Init");
+      store = await openStore(directory: objectBoxDirectory.path)
+          .timeout(_dbOpenTimeout, onTimeout: () {
+        throw TimeoutException("Desktop openStore() timed out after ${_dbOpenTimeout.inSeconds}s");
+      });
+      Logger.info("Opened desktop ObjectBox store in ${sw.elapsedMilliseconds}ms", tag: "DB-Init");
     } catch (e, s) {
-      if (Platform.isLinux) {
-        Logger.debug("Another instance is probably running. Sending foreground signal");
+      sw.stop();
+      final errorMsg = e.toString();
+
+      if (Platform.isLinux && _isDbLockError(errorMsg)) {
+        Logger.debug("Another instance is probably running. Sending foreground signal", tag: "DB-Init");
         final instanceFile = File(join(fs.appDocDir.path, '.instance'));
         instanceFile.openSync(mode: FileMode.write).closeSync();
         exit(0);
       }
 
-      Logger.error("Failed to initialize desktop database!", error: e, trace: s);
+      if (_isDbCorruptionError(errorMsg)) {
+        Logger.error("Desktop database appears corrupted. Backing up and recreating...", error: e, trace: s, tag: "DB-Init");
+        try {
+          if (objectBoxDirectory.existsSync()) {
+            final backupDir = Directory("${objectBoxDirectory.path}.backup");
+            if (backupDir.existsSync()) {
+              backupDir.deleteSync(recursive: true);
+            }
+            objectBoxDirectory.renameSync(backupDir.path);
+            Logger.info("Corrupted database backed up to ${backupDir.path}", tag: "DB-Init");
+          }
+          objectBoxDirectory.createSync(recursive: true);
+          store = await openStore(directory: objectBoxDirectory.path)
+              .timeout(_dbOpenTimeout, onTimeout: () {
+            throw TimeoutException("Desktop openStore() timed out during corruption recovery");
+          });
+          Logger.info("Successfully recreated desktop ObjectBox store after corruption recovery. Old data backed up.", tag: "DB-Init");
+          return;
+        } catch (recoveryError, recoveryTrace) {
+          Logger.error("Desktop database corruption recovery failed!", error: recoveryError, trace: recoveryTrace, tag: "DB-Init");
+        }
+      }
+
+      Logger.error("Failed to initialize desktop database after ${sw.elapsedMilliseconds}ms!", error: e, trace: s, tag: "DB-Init");
     }
   }
 

--- a/lib/helpers/backend/startup_tasks.dart
+++ b/lib/helpers/backend/startup_tasks.dart
@@ -27,8 +27,12 @@ class StartupTasks {
   static Future<void> initStartupServices({bool isBubble = false}) async {
     debugPrint("Initializing startup services...");
 
-    await RustLib.init();
-    
+    try {
+      await RustLib.init().timeout(const Duration(seconds: 30));
+    } on TimeoutException {
+      throw Exception("RustLib.init() timed out after 30 seconds. The Rust bridge failed to load.");
+    }
+
     // First, initialize the filesystem service as it's used by other necessary services
     await fs.init();
 
@@ -45,7 +49,11 @@ class StartupTasks {
 
     // The next thing we need to do is initialize the database.
     // If the database is not initialized, we cannot do anything.
-    await Database.init();
+    try {
+      await Database.init().timeout(const Duration(seconds: 30));
+    } on TimeoutException {
+      throw Exception("Database.init() timed out after 30 seconds. The database may be locked or corrupted.");
+    }
 
     // Load FCM data into settings from the database
     // We only need to do this for the main startup
@@ -71,14 +79,22 @@ class StartupTasks {
   }
 
   static Future<void> initIsolateServices() async {
-    await RustLib.init();
+    try {
+      await RustLib.init().timeout(const Duration(seconds: 30));
+    } on TimeoutException {
+      throw Exception("RustLib.init() timed out after 30 seconds. The Rust bridge failed to load.");
+    }
 
     debugPrint("Initializing isolate services...");
     await fs.init(headless: true);
     await Logger.init();
     Logger.debug("Initializing isolate services...");
     await ss.init(headless: true);
-    await Database.init();
+    try {
+      await Database.init().timeout(const Duration(seconds: 30));
+    } on TimeoutException {
+      throw Exception("Database.init() timed out after 30 seconds. The database may be locked or corrupted.");
+    }
     await mcs.init(headless: true);
     await ls.init(headless: true);
   }
@@ -89,7 +105,11 @@ class StartupTasks {
     await Logger.init();
     Logger.debug("Initializing incremental sync services...");
     await ss.init();
-    await Database.init();
+    try {
+      await Database.init().timeout(const Duration(seconds: 30));
+    } on TimeoutException {
+      throw Exception("Database.init() timed out after 30 seconds. The database may be locked or corrupted.");
+    }
   }
 
   static Future<void> onStartup() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -72,8 +72,6 @@ Future<Null> initApp(bool bubble, List<String> arguments) async {
     () async {
       WidgetsFlutterBinding.ensureInitialized();
 
-      await StartupTasks.initStartupServices(isBubble: bubble);
-
       /* ----- RANDOM STUFF INITIALIZATION ----- */
       HttpOverrides.global = BadCertOverride();
       dynamic exception;
@@ -84,30 +82,18 @@ Future<Null> initApp(bool bubble, List<String> arguments) async {
       };
 
       try {
+        await StartupTasks.initStartupServices(isBubble: bubble);
+
         // Once all the services are initialized, we need to perform some
         // startup tasks to ensure that the app has the information it needs.
-        StartupTasks.onStartup().then((_) {
-          Logger.info("Startup tasks completed");
-        }).catchError((e, s) {
-          Logger.error("Failed to complete startup tasks!", error: e, trace: s);
-        });
+        await StartupTasks.onStartup();
+        Logger.info("Startup tasks completed");
 
         /* ----- DATE FORMATTING INITIALIZATION ----- */
         await initializeDateFormatting();
 
         /* ----- MEDIAKIT INITIALIZATION ----- */
         MediaKit.ensureInitialized();
-
-        /* ----- SPLASH SCREEN INITIALIZATION ----- */
-        if (!ss.settings.finishedSetup.value && !kIsWeb && !kIsDesktop) {
-          runApp(MaterialApp(
-              home: SplashScreen(shouldNavigate: false),
-              theme: ThemeData(
-                colorScheme: ColorScheme.fromSwatch(
-                    backgroundColor:
-                        PlatformDispatcher.instance.platformBrightness == Brightness.dark ? Colors.black : Colors.white),
-              )));
-        }
 
         /* ----- ANDROID SPECIFIC INITIALIZATION ----- */
         if (!kIsWeb && !kIsDesktop) {
@@ -167,7 +153,11 @@ Future<Null> initApp(bool bubble, List<String> arguments) async {
               await windowManager.show();
             }
             if (!(ss.canAuthenticate && ss.settings.shouldSecure.value)) {
-              chats.init();
+              try {
+                await chats.init();
+              } catch (e, s) {
+                Logger.error("Failed to initialize chats on desktop", error: e, trace: s);
+              }
               socket;
             }
           });
@@ -203,6 +193,13 @@ Future<Null> initApp(bool bubble, List<String> arguments) async {
     },
     (dynamic error, StackTrace stackTrace) {
       Logger.error("Unhandled Exception", trace: stackTrace, error: error);
+      // If an unhandled error occurs before runApp() has been called,
+      // the user would see a blank screen. Attempt to show error UI.
+      try {
+        runApp(FailureToStart(e: error, s: stackTrace));
+      } catch (_) {
+        // runApp may itself fail if binding isn't initialized
+      }
     }
   );
 }
@@ -324,7 +321,7 @@ class Main extends StatelessWidget {
           child: SecureApplication(
             child: Builder(
               builder: (context) {
-                if (ss.canAuthenticate && (!ls.isAlive || !StartupTasks.uiReady.isCompleted)) {
+                if (ss.canAuthenticate && !ls.isAlive) {
                   if (ss.settings.shouldSecure.value) {
                     SecureApplicationProvider.of(context, listen: false)!.lock();
                     if (ss.settings.securityLevel.value == SecurityLevel.locked_and_secured) {
@@ -349,8 +346,12 @@ class Main extends StatelessWidget {
                           if (result) {
                             SecureApplicationProvider.of(context, listen: false)!.authSuccess(unlock: true);
                             if (kIsDesktop) {
-                              Future.delayed(Duration.zero, () {
-                                chats.init();
+                              Future.delayed(Duration.zero, () async {
+                                try {
+                                  await chats.init();
+                                } catch (e, s) {
+                                  Logger.error("Failed to initialize chats after auth", error: e, trace: s);
+                                }
                                 socket;
                               });
                             }
@@ -388,8 +389,12 @@ class Main extends StatelessWidget {
                                       if (didAuthenticate) {
                                         controller!.authSuccess(unlock: true);
                                         if (kIsDesktop) {
-                                          Future.delayed(Duration.zero, () {
-                                            chats.init();
+                                          Future.delayed(Duration.zero, () async {
+                                            try {
+                                              await chats.init();
+                                            } catch (e, s) {
+                                              Logger.error("Failed to initialize chats after auth", error: e, trace: s);
+                                            }
                                             socket;
                                           });
                                         }
@@ -427,6 +432,8 @@ class _HomeState extends OptimizedState<Home> with WidgetsBindingObserver, TrayL
   final ReceivePort port = ReceivePort();
   bool serverCompatible = true;
   bool fullyLoaded = false;
+  bool startupTimedOut = false;
+  Timer? _watchdogTimer;
 
   @override
   void initState() {
@@ -434,6 +441,15 @@ class _HomeState extends OptimizedState<Home> with WidgetsBindingObserver, TrayL
 
     // Bind the lifecycle events
     WidgetsBinding.instance.addObserver(this);
+
+    // Watchdog: if startup hasn't completed in 60s, show a warning
+    _watchdogTimer = Timer(const Duration(seconds: 60), () {
+      if (!fullyLoaded && !ss.settings.finishedSetup.value && mounted) {
+        setState(() {
+          startupTimedOut = true;
+        });
+      }
+    });
 
     /* ----- APP REFRESH LISTENER INITIALIZATION ----- */
     eventDispatcher.stream.listen((event) {
@@ -457,11 +473,15 @@ class _HomeState extends OptimizedState<Home> with WidgetsBindingObserver, TrayL
       };
       /* ----- SERVER VERSION CHECK ----- */
       if (kIsWeb && ss.settings.finishedSetup.value) {
-        int version = (await ss.getServerDetails()).item4;
-        if (version < 42) {
-          setState(() {
-            serverCompatible = false;
-          });
+        try {
+          int version = (await ss.getServerDetails().timeout(const Duration(seconds: 10))).item4;
+          if (version < 42) {
+            setState(() {
+              serverCompatible = false;
+            });
+          }
+        } catch (e) {
+          Logger.error("Failed to fetch server details", error: e);
         }
 
         /* ----- CTRL-F OVERRIDE ----- */
@@ -473,55 +493,60 @@ class _HomeState extends OptimizedState<Home> with WidgetsBindingObserver, TrayL
       }
 
       if (kIsDesktop) {
-        if (Platform.isWindows) {
-          /* ----- CONTACT IMAGE CACHE DELETION ----- */
-          Directory temp = Directory(join(fs.appDocDir.path, "temp"));
-          if (await temp.exists()) await temp.delete(recursive: true);
+        try {
+          if (Platform.isWindows) {
+            /* ----- CONTACT IMAGE CACHE DELETION ----- */
+            Directory temp = Directory(join(fs.appDocDir.path, "temp"));
+            if (await temp.exists()) await temp.delete(recursive: true);
 
-          /* ----- BADGE ICON LISTENER ----- */
-          GlobalChatService.unreadCount.listen((count) async {
-            if (count == 0) {
-                await WindowsTaskbar.resetOverlayIcon();
-              } else if (count <= 9) {
-                await WindowsTaskbar.setOverlayIcon(ThumbnailToolbarAssetIcon('assets/badges/badge-$count.ico'));
-              } else {
-                await WindowsTaskbar.setOverlayIcon(ThumbnailToolbarAssetIcon('assets/badges/badge-10.ico'));
-              }
-          });
-
-          /* ----- WINDOW EFFECT INITIALIZATION ----- */
-          eventDispatcher.stream.listen((event) async {
-            if (event.item1 == 'theme-update') {
-              EasyDebounce.debounce('window-effect', const Duration(milliseconds: 500), () async {
-                if (mounted) {
-                  await WindowEffects.setEffect(color: context.theme.colorScheme.background);
+            /* ----- BADGE ICON LISTENER ----- */
+            GlobalChatService.unreadCount.listen((count) async {
+              if (count == 0) {
+                  await WindowsTaskbar.resetOverlayIcon();
+                } else if (count <= 9) {
+                  await WindowsTaskbar.setOverlayIcon(ThumbnailToolbarAssetIcon('assets/badges/badge-$count.ico'));
+                } else {
+                  await WindowsTaskbar.setOverlayIcon(ThumbnailToolbarAssetIcon('assets/badges/badge-10.ico'));
                 }
-              });
-            }
-          });
+            });
 
-          Future(() => eventDispatcher.emit("theme-update", null));
+            /* ----- WINDOW EFFECT INITIALIZATION ----- */
+            eventDispatcher.stream.listen((event) async {
+              if (event.item1 == 'theme-update') {
+                EasyDebounce.debounce('window-effect', const Duration(milliseconds: 500), () async {
+                  if (mounted) {
+                    await WindowEffects.setEffect(color: context.theme.colorScheme.background);
+                  }
+                });
+              }
+            });
+
+            Future(() => eventDispatcher.emit("theme-update", null));
+          }
+
+          /* ----- SYSTEM TRAY INITIALIZATION ----- */
+          await initSystemTray();
+          if (Platform.isWindows) {
+            systemTray.registerSystemTrayEventHandler((eventName) {
+              if (eventName == st.kSystemTrayEventClick) {
+                onTrayIconMouseDown();
+              } else if (eventName == st.kSystemTrayEventRightClick) {
+                onTrayIconRightMouseDown();
+              }
+            });
+          } else {
+            trayManager.addListener(this);
+          }
+
+          /* ----- NOTIFICATIONS INITIALIZATION ----- */
+          await localNotifier.setup(appName: "BlueBubbles");
+        } catch (e) {
+          Logger.error("Failed to initialize desktop features", error: e);
         }
-
-        /* ----- SYSTEM TRAY INITIALIZATION ----- */
-        await initSystemTray();
-        if (Platform.isWindows) {
-          systemTray.registerSystemTrayEventHandler((eventName) {
-            if (eventName == st.kSystemTrayEventClick) {
-              onTrayIconMouseDown();
-            } else if (eventName == st.kSystemTrayEventRightClick) {
-              onTrayIconRightMouseDown();
-            }
-          });
-        } else {
-          trayManager.addListener(this);
-        }
-
-        /* ----- NOTIFICATIONS INITIALIZATION ----- */
-        await localNotifier.setup(appName: "BlueBubbles");
       }
 
       if (!ss.settings.finishedSetup.value) {
+        _watchdogTimer?.cancel();
         setState(() {
           fullyLoaded = true;
         });
@@ -565,6 +590,7 @@ class _HomeState extends OptimizedState<Home> with WidgetsBindingObserver, TrayL
 
   @override
   void dispose() {
+    _watchdogTimer?.cancel();
     // Clean up observer when app is fully closed
     WidgetsBinding.instance.removeObserver(this);
     windowManager.removeListener(DesktopWindowListener.instance);
@@ -636,6 +662,33 @@ class _HomeState extends OptimizedState<Home> with WidgetsBindingObserver, TrayL
                       showUnknownSenders: false,
                     );
                   } else {
+                    if (startupTimedOut && !fullyLoaded && !kIsWeb && !kIsDesktop) {
+                      return Center(
+                        child: Padding(
+                          padding: const EdgeInsets.all(24.0),
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              const Icon(Icons.warning_amber_rounded, size: 48, color: Colors.orange),
+                              const SizedBox(height: 16),
+                              Text(
+                                "Startup is taking longer than expected.",
+                                style: context.theme.textTheme.titleMedium,
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(height: 8),
+                              Text(
+                                "You can keep waiting or restart the app.",
+                                style: context.theme.textTheme.bodyMedium,
+                                textAlign: TextAlign.center,
+                              ),
+                              const SizedBox(height: 24),
+                              const CircularProgressIndicator(),
+                            ],
+                          ),
+                        ),
+                      );
+                    }
                     return PopScope(
                       canPop: false,
                       child: TitleBarWrapper(


### PR DESCRIPTION
## Summary

Fixes intermittent black screen on app startup caused by race conditions, missing timeouts, and fire-and-forget async patterns in the initialization flow.

- **Await critical startup tasks** instead of fire-and-forget patterns that let the UI render before services are ready
- **Add timeouts** (30s) to Rust bridge and database initialization to prevent indefinite hangs
- **Remove double `runApp()` call** that could leave users stuck on a blank splash screen
- **Fix desktop race condition** where `chats.init()` and socket were not awaited
- **Fix circular dependency** in security gate's `uiReady` check
- **Add database resilience**: retry with backoff for lock contention, backup-before-reset for corruption recovery
- **Add error boundaries**: watchdog timer, enhanced error UI, proper try-catch throughout startup

## Problem

Users intermittently see a black screen when launching the app. The root causes:

1. `StartupTasks.onStartup()` was called with `.then()/.catchError()` (fire-and-forget) — the UI rendered before critical services finished initializing
2. `RustLib.init()` and `Database.init()` had **no timeout** — if the Rust bridge failed to load or the ObjectBox database was locked, the app hung forever
3. `runApp()` was called **twice** (splash + main) — exceptions between the calls left users on a blank screen
4. On desktop, `chats.init()` and `socket` were fire-and-forget inside `doWhenWindowReady()` — UI rendered with no data
5. Security gate checked `!StartupTasks.uiReady.isCompleted`, but `uiReady` only completed in a post-frame callback — circular dependency
6. Database `Store.attach()` could block indefinitely on lock contention with no timeout or retry

## Changes by file

### `lib/main.dart` (5 fixes)

| Fix | Before | After |
|-----|--------|-------|
| Startup tasks | `onStartup().then().catchError()` (fire-and-forget) | `await StartupTasks.onStartup()` |
| Double runApp | Two `runApp()` calls (splash + main) | Single `runApp()` — Home widget handles splash |
| Desktop init | `chats.init(); socket;` (not awaited) | `await chats.init()` with try-catch in 3 locations |
| Security gate | `!ls.isAlive \|\| !uiReady.isCompleted` (circular) | `!ls.isAlive` only — uiReady was always incomplete during build |
| Error handling | Unhandled async errors in Home.initState | try-catch with timeouts (10s for server details), watchdog timer (60s) |

### `lib/helpers/backend/startup_tasks.dart` (1 fix)

- 30-second timeouts on `RustLib.init()` and `Database.init()` across all 3 init paths
- `TimeoutException` caught and re-thrown with descriptive messages

### `lib/database/database.dart` (5 fixes)

| Fix | Detail |
|-----|--------|
| Timeouts | 10s timeout on `Store.attach()` and `openStore()` (mobile + desktop) |
| Error detection | Case-insensitive `_isDbLockError()` and `_isDbCorruptionError()` helpers |
| Retry + backoff | 3 retries with 500ms/1000ms/1500ms backoff for lock errors |
| Corruption recovery | **Backs up** corrupted DB to `.backup` before recreating (preserves data) |
| Logging | Stopwatch-based init timing logs tagged `DB-Init` |

### `lib/app/layouts/startup/failure_to_start.dart` (enhanced)

- Error icon, context-aware messaging (detects timeout errors specifically)
- "Copy Error Details" button for bug reports
- SafeArea + SingleChildScrollView for long stack traces

## QA Review Results

Four independent QA reviews were conducted in parallel:

| Review | Scope | Result | Findings |
|--------|-------|--------|----------|
| **main.dart** | All 5 changes from different engineers | **PASS** | 1 false-positive (security gate change was intentional circular dep fix); `socket;` lines confirmed as standard GetX lazy init |
| **startup_tasks.dart** | Timeout implementation | **PASS** | All 3 init paths covered; timeout pattern correct; non-timeout errors propagate to existing try-catch |
| **database.dart** | Lock/corruption/retry changes | **PASS after fixes** | 3 critical issues found and fixed: (1) corruption recovery now backs up before deleting, (2) error matching now case-insensitive, (3) added missing `onTimeout` handler in recovery path |
| **Static analysis** | Import/dependency check | **PASS** | All imports correct; no missing deps; 1 pre-existing duplicate import (not introduced by this PR) |

## Design Decisions

- **Timeout values**: 30s for Rust/DB init (outer), 10s for individual DB open calls (inner) — allows retries within the outer timeout window
- **Database corruption recovery backs up, doesn't delete**: Users deserve to keep their data. The `.backup` directory can be manually restored if needed
- **`uiReady` completer kept but removed from security gate**: Still used by `intents_service` and `chats_service` via `waitForUI()` — only the circular gate check was removed
- **`socket;` access pattern preserved**: This is standard GetX lazy initialization, not dead code
- **Watchdog timer (60s) only on mobile pre-setup**: Desktop and post-setup flows have different lifecycle management

## Test plan

- [ ] Cold start on Android — verify no black screen
- [ ] Cold start on desktop (macOS/Linux/Windows) — verify window appears with content
- [ ] Kill app during startup, relaunch — verify recovery (tests DB lock handling)
- [ ] Test with security/biometric lock enabled — verify lock screen appears correctly
- [ ] Test first-time setup flow — verify splash → setup transition works
- [ ] Simulate slow init (e.g., slow network) — verify watchdog timer shows warning after 60s
- [ ] Verify FailureToStart screen appears on init errors (can test by temporarily breaking DB path)
- [ ] Verify "Copy Error Details" button works on FailureToStart screen
- [ ] Regression: verify normal messaging flow works after startup completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)