### PR TITLE
Add HEIC image support on Linux via flutter_image_compress_linux

### DIFF
--- a/lib/services/ui/attachments_service.dart
+++ b/lib/services/ui/attachments_service.dart
@@ -346,7 +346,7 @@ class AttachmentsService extends GetxService {
     }
 
     // Handle getting heic and tiff images
-    if (attachment.mimeType!.contains('image/hei') && !kIsDesktop) {
+    if (attachment.mimeType!.contains('image/hei') && !Platform.isWindows) {
       if (await File("$filePath.png").exists()) {
         originalFile = File("$filePath.png");
       } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ dependencies:
   flutter_displaymode: ^0.6.0 # android only
   flutter_dotenv: ^5.1.0
   flutter_image_compress: ^2.2.0
+  flutter_image_compress_linux: ^0.1.0
   flutter_improved_scrolling: ^0.0.3
   flutter_isolate: ^2.1.0
   flutter_keyboard_visibility: ^6.0.0 # no desktop support


### PR DESCRIPTION
Adds HEIC image rendering support on Linux desktop.

## Problem

HEIC images sent from iPhones display "Failed to display image" on Linux (#117). This is because `flutter_image_compress` has no Linux platform implementation, and the HEIC conversion code in `attachments_service.dart` was gated behind `!kIsDesktop`, skipping it entirely on desktop platforms.

## Solution

- Added [`flutter_image_compress_linux`](https://pub.dev/packages/flutter_image_compress_linux) as a dependency — a federated platform implementation that provides JPEG, PNG, WebP, and HEIC compression on Linux via dart:ffi with native C codecs (libjpeg-turbo, libpng, libwebp, libheif)
- Changed `!kIsDesktop` to `!Platform.isWindows` so HEIC conversion runs on Linux and macOS (which already has `flutter_image_compress_macos`), while still skipping Windows which has no implementation yet

## Changes

- `pubspec.yaml`: Added `flutter_image_compress_linux: ^0.1.0` to dependencies
- `lib/services/ui/attachments_service.dart`: Changed `!kIsDesktop` to `!Platform.isWindows` on line 349

## Testing

- Built and tested locally on Pop!_OS 24.04
- Confirmed HEIC images from iPhone conversations render correctly
- All existing image paths (attachment picker, message bubbles, fullscreen viewer, media gallery) flow through the same `loadAndGetProperties()` method, so the single change covers all cases

Addresses #117 (Linux). Windows HEIC support would require a separate `flutter_image_compress_windows` package.