### PR TITLE
Fix widget, animation, and controller lifecycle leaks

### DIFF
--- a/lib/app/animations/balloon_classes.dart
+++ b/lib/app/animations/balloon_classes.dart
@@ -14,7 +14,7 @@ class BalloonController implements Listenable {
   final Random random = Random();
   Size windowSize;
 
-  late Ticker ticker;
+  Ticker? ticker;
 
   bool isPlaying = false;
   bool requestedToStop = false;
@@ -28,6 +28,7 @@ class BalloonController implements Listenable {
     isPlaying = true;
     autoLaunchDuration = const Duration(milliseconds: 100);
     lastAutoLaunch = Duration.zero;
+    ticker?.dispose();
     ticker = vsync.createTicker(update)..start();
   }
 
@@ -53,7 +54,8 @@ class BalloonController implements Listenable {
 
   void dispose() {
     listeners.clear();
-    ticker.dispose();
+    ticker?.dispose();
+    ticker = null;
   }
 
   void update(Duration elapsedDuration) {
@@ -82,8 +84,9 @@ class BalloonController implements Listenable {
       return element.position.y < -100 || element.position.x < -100;
     });
     if (balloons.isEmpty && requestedToStop) {
-      ticker.stop();
-      ticker.dispose();
+      ticker?.stop();
+      ticker?.dispose();
+      ticker = null;
       isPlaying = false;
       requestedToStop = false;
       stopFunc?.call();

--- a/lib/app/animations/celebration_class.dart
+++ b/lib/app/animations/celebration_class.dart
@@ -14,6 +14,7 @@ class CelebrationController extends FireworkController {
     isPlaying = true;
     autoLaunchDuration = const Duration(milliseconds: 100);
     lastAutoLaunch = Duration.zero;
+    ticker?.dispose();
     ticker = vsync.createTicker(update)..start();
   }
 
@@ -41,7 +42,8 @@ class CelebrationController extends FireworkController {
   @override
   void dispose() {
     listeners.clear();
-    ticker.dispose();
+    ticker?.dispose();
+    ticker = null;
   }
 
   @override
@@ -63,8 +65,9 @@ class CelebrationController extends FireworkController {
 
     particles.removeWhere((element) => element.alpha <= 0);
     if (particles.isEmpty && requestedToStop) {
-      ticker.stop();
-      ticker.dispose();
+      ticker?.stop();
+      ticker?.dispose();
+      ticker = null;
       isPlaying = false;
       requestedToStop = false;
       hasCreatedParticles = false;

--- a/lib/app/animations/fireworks_classes.dart
+++ b/lib/app/animations/fireworks_classes.dart
@@ -23,7 +23,7 @@ class FireworkController implements Listenable {
   Size windowSize;
   double globalHue = 42;
 
-  late Ticker ticker;
+  Ticker? ticker;
 
   bool hasCreatedParticles = false;
   bool isPlaying = false;
@@ -41,6 +41,7 @@ class FireworkController implements Listenable {
     isPlaying = true;
     autoLaunchDuration = const Duration(milliseconds: 100);
     lastAutoLaunch = Duration.zero;
+    ticker?.dispose();
     ticker = vsync.createTicker(update)..start();
   }
 
@@ -66,7 +67,8 @@ class FireworkController implements Listenable {
 
   void dispose() {
     listeners.clear();
-    ticker.dispose();
+    ticker?.dispose();
+    ticker = null;
   }
 
   void update(Duration elapsedDuration) {
@@ -113,8 +115,9 @@ class FireworkController implements Listenable {
     });
     particles.removeWhere((element) => element.alpha <= 0);
     if (particles.isEmpty && requestedToStop && hasCreatedParticles) {
-      ticker.stop();
-      ticker.dispose();
+      ticker?.stop();
+      ticker?.dispose();
+      ticker = null;
       isPlaying = false;
       requestedToStop = false;
       hasCreatedParticles = false;

--- a/lib/app/animations/laser_classes.dart
+++ b/lib/app/animations/laser_classes.dart
@@ -16,7 +16,7 @@ class LaserController implements Listenable {
   final Random random = Random();
   Size windowSize;
 
-  late Ticker ticker;
+  Ticker? ticker;
   late Point<double> position;
   late double size;
   double globalHue = 42;
@@ -34,6 +34,7 @@ class LaserController implements Listenable {
     autoLaunchDuration = const Duration(milliseconds: 500);
     lastAutoLaunch = Duration.zero;
     position = Point((bubbleDimensions.left + bubbleDimensions.right) / 2, (bubbleDimensions.top + bubbleDimensions.bottom) / 2);
+    ticker?.dispose();
     ticker = vsync.createTicker(update)..start();
   }
 
@@ -58,7 +59,8 @@ class LaserController implements Listenable {
 
   void dispose() {
     listeners.clear();
-    ticker.dispose();
+    ticker?.dispose();
+    ticker = null;
   }
 
   void update(Duration elapsedDuration) {
@@ -103,8 +105,9 @@ class LaserController implements Listenable {
     }
 
     if (elapsedDuration.inSeconds > 5 && requestedToStop) {
-      ticker.stop();
-      ticker.dispose();
+      ticker?.stop();
+      ticker?.dispose();
+      ticker = null;
       isPlaying = false;
       requestedToStop = false;
       laser = null;

--- a/lib/app/animations/love_classes.dart
+++ b/lib/app/animations/love_classes.dart
@@ -14,7 +14,7 @@ class LoveController implements Listenable {
   final Random random = Random();
   Size windowSize;
 
-  late Ticker ticker;
+  Ticker? ticker;
   late Point<double> position;
 
   bool isPlaying = false;
@@ -30,6 +30,7 @@ class LoveController implements Listenable {
     autoLaunchDuration = const Duration(milliseconds: 100);
     lastAutoLaunch = Duration.zero;
     position = startPos;
+    ticker?.dispose();
     ticker = vsync.createTicker(update)..start();
   }
 
@@ -55,7 +56,8 @@ class LoveController implements Listenable {
 
   void dispose() {
     listeners.clear();
-    ticker.dispose();
+    ticker?.dispose();
+    ticker = null;
   }
 
   void update(Duration elapsedDuration) {
@@ -75,8 +77,9 @@ class LoveController implements Listenable {
     heart!.update();
 
     if (heart!.position.y < -200 && requestedToStop) {
-      ticker.stop();
-      ticker.dispose();
+      ticker?.stop();
+      ticker?.dispose();
+      ticker = null;
       isPlaying = false;
       requestedToStop = false;
       heart = null;

--- a/lib/app/animations/spotlight_classes.dart
+++ b/lib/app/animations/spotlight_classes.dart
@@ -14,7 +14,7 @@ class SpotlightController implements Listenable {
   final Random random = Random();
   Size windowSize;
 
-  late Ticker ticker;
+  Ticker? ticker;
   late Point<double> position;
   late double size;
 
@@ -32,6 +32,7 @@ class SpotlightController implements Listenable {
     lastAutoLaunch = Duration.zero;
     position = Point((bubbleDimensions.left + bubbleDimensions.right) / 2, (bubbleDimensions.top + bubbleDimensions.bottom) / 2);
     size = max(bubbleDimensions.width, bubbleDimensions.height) + 50;
+    ticker?.dispose();
     ticker = vsync.createTicker(update)..start();
   }
 
@@ -57,7 +58,8 @@ class SpotlightController implements Listenable {
 
   void dispose() {
     listeners.clear();
-    ticker.dispose();
+    ticker?.dispose();
+    ticker = null;
   }
 
   void update(Duration elapsedDuration) {
@@ -76,8 +78,9 @@ class SpotlightController implements Listenable {
     spotlight!.update(elapsedDuration);
 
     if (spotlight!.stop < 0 && requestedToStop) {
-      ticker.stop();
-      ticker.dispose();
+      ticker?.stop();
+      ticker?.dispose();
+      ticker = null;
       isPlaying = false;
       requestedToStop = false;
       spotlight = null;

--- a/lib/app/components/avatars/contact_avatar_group_widget.dart
+++ b/lib/app/components/avatars/contact_avatar_group_widget.dart
@@ -31,7 +31,7 @@ class ContactAvatarGroupWidget extends StatefulWidget {
 }
 
 class _ContactAvatarGroupWidgetState extends OptimizedState<ContactAvatarGroupWidget> {
-  late final List<Handle> participants = widget.chat?.participants ?? widget.participants ?? [];
+  late List<Handle> participants;
   final Map materialGeneration = {
     2: [24.5/40, 10.5/40, [Alignment.topRight, Alignment.bottomLeft]],
     3: [21.5/40, 9/40, [Alignment.bottomRight, Alignment.bottomLeft, Alignment.topCenter]],
@@ -41,6 +41,20 @@ class _ContactAvatarGroupWidgetState extends OptimizedState<ContactAvatarGroupWi
   @override
   void initState() {
     super.initState();
+    _syncParticipants();
+  }
+
+  @override
+  void didUpdateWidget(covariant ContactAvatarGroupWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _syncParticipants();
+  }
+
+  void _syncParticipants() {
+    // Copy before sorting. Chat.participants is backed by the persisted
+    // relation, so sorting it in place can make participant order appear to
+    // change as a side effect of rendering.
+    participants = List<Handle>.from(widget.chat?.participants ?? widget.participants ?? []);
     participants.sort((a, b) {
       bool avatarA = a.contact?.avatar?.isNotEmpty ?? false;
       bool avatarB = b.contact?.avatar?.isNotEmpty ?? false;

--- a/lib/app/components/avatars/contact_avatar_widget.dart
+++ b/lib/app/components/avatars/contact_avatar_widget.dart
@@ -38,12 +38,14 @@ class ContactAvatarWidget extends StatefulWidget {
 
 class _ContactAvatarWidgetState extends OptimizedState<ContactAvatarWidget> {
   Contact? get contact => widget.contact ?? widget.handle?.contact;
-  String get keyPrefix => widget.handle?.address ?? randomString(8);
+  late final String _keyPrefix;
+  String get keyPrefix => _keyPrefix;
   late final StreamSubscription _avatarRefreshSubscription;
 
   @override
   void initState() {
     super.initState();
+    _keyPrefix = widget.handle?.address ?? randomString(8);
     _avatarRefreshSubscription = eventDispatcher.stream.listen((event) {
       if (!mounted) return;
       if (event.item1 != 'refresh-avatar') return;

--- a/lib/app/components/avatars/contact_avatar_widget.dart
+++ b/lib/app/components/avatars/contact_avatar_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/database/models.dart';
@@ -37,16 +39,24 @@ class ContactAvatarWidget extends StatefulWidget {
 class _ContactAvatarWidgetState extends OptimizedState<ContactAvatarWidget> {
   Contact? get contact => widget.contact ?? widget.handle?.contact;
   String get keyPrefix => widget.handle?.address ?? randomString(8);
+  late final StreamSubscription _avatarRefreshSubscription;
 
   @override
   void initState() {
     super.initState();
-    eventDispatcher.stream.listen((event) {
+    _avatarRefreshSubscription = eventDispatcher.stream.listen((event) {
+      if (!mounted) return;
       if (event.item1 != 'refresh-avatar') return;
       if (event.item2[0] != widget.handle?.address) return;
       widget.handle?.color = event.item2[1];
       setState(() {});
     });
+  }
+
+  @override
+  void dispose() {
+    _avatarRefreshSubscription.cancel();
+    super.dispose();
   }
 
   void onAvatarTap() async {

--- a/lib/app/components/avatars/contact_avatar_widget.dart
+++ b/lib/app/components/avatars/contact_avatar_widget.dart
@@ -40,7 +40,7 @@ class _ContactAvatarWidgetState extends OptimizedState<ContactAvatarWidget> {
   Contact? get contact => widget.contact ?? widget.handle?.contact;
   late final String _keyPrefix;
   String get keyPrefix => _keyPrefix;
-  late final StreamSubscription _avatarRefreshSubscription;
+  StreamSubscription? _avatarRefreshSubscription;
 
   @override
   void initState() {
@@ -57,7 +57,7 @@ class _ContactAvatarWidgetState extends OptimizedState<ContactAvatarWidget> {
 
   @override
   void dispose() {
-    _avatarRefreshSubscription.cancel();
+    _avatarRefreshSubscription?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_list/widgets/conversation_list_fab.dart
+++ b/lib/app/layouts/conversation_list/widgets/conversation_list_fab.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bluebubbles/app/layouts/conversation_list/pages/conversation_list.dart';
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/app/wrappers/theme_switcher.dart';
@@ -18,6 +20,8 @@ class ConversationListFAB extends CustomStateful<ConversationListController> {
 }
 
 class _ConversationListFABState extends CustomState<ConversationListFAB, void, ConversationListController> {
+  late final StreamSubscription _avatarOnlySubscription;
+
   void _focusBackToList() {
     if (!FocusScope.of(context).focusInDirection(TraversalDirection.left)) {
       FocusScope.of(context).previousFocus();
@@ -31,27 +35,29 @@ class _ConversationListFABState extends CustomState<ConversationListFAB, void, C
     const SingleActivator(LogicalKeyboardKey.space): () => controller.openNewChatCreator(context),
   };
 
+  void _handleMaterialScroll() {
+    if (!mounted || !material) return;
+    if (controller.materialScrollStartPosition - controller.materialScrollController.offset < -75
+        && controller.materialScrollController.position.userScrollDirection == ScrollDirection.reverse
+        && controller.showMaterialFABText) {
+      setState(() {
+        controller.showMaterialFABText = false;
+      });
+    } else if (controller.materialScrollStartPosition - controller.materialScrollController.offset > 75
+        && controller.materialScrollController.position.userScrollDirection == ScrollDirection.forward
+        && !controller.showMaterialFABText) {
+      setState(() {
+        controller.showMaterialFABText = true;
+      });
+    }
+  }
+
   @override
   void initState() {
     super.initState();
 
-    controller.materialScrollController.addListener(() {
-      if (!material) return;
-      if (controller.materialScrollStartPosition - controller.materialScrollController.offset < -75
-          && controller.materialScrollController.position.userScrollDirection == ScrollDirection.reverse
-          && controller.showMaterialFABText) {
-        setState(() {
-          controller.showMaterialFABText = false;
-        });
-      } else if (controller.materialScrollStartPosition - controller.materialScrollController.offset > 75
-          && controller.materialScrollController.position.userScrollDirection == ScrollDirection.forward
-          && !controller.showMaterialFABText) {
-        setState(() {
-          controller.showMaterialFABText = true;
-        });
-      }
-    });
-    ns.listener.stream.listen((event) {
+    controller.materialScrollController.addListener(_handleMaterialScroll);
+    _avatarOnlySubscription = ns.listener.stream.listen((event) {
       if (!mounted) return;
       if (ns.isAvatarOnly(context) && controller.showMaterialFABText) {
         setState(() {
@@ -59,6 +65,13 @@ class _ConversationListFABState extends CustomState<ConversationListFAB, void, C
         });
       }
     });
+  }
+
+  @override
+  void dispose() {
+    controller.materialScrollController.removeListener(_handleMaterialScroll);
+    _avatarOnlySubscription.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/app/layouts/conversation_list/widgets/conversation_list_fab.dart
+++ b/lib/app/layouts/conversation_list/widgets/conversation_list_fab.dart
@@ -20,7 +20,7 @@ class ConversationListFAB extends CustomStateful<ConversationListController> {
 }
 
 class _ConversationListFABState extends CustomState<ConversationListFAB, void, ConversationListController> {
-  late final StreamSubscription _avatarOnlySubscription;
+  StreamSubscription? _avatarOnlySubscription;
 
   void _focusBackToList() {
     if (!FocusScope.of(context).focusInDirection(TraversalDirection.left)) {
@@ -70,7 +70,7 @@ class _ConversationListFABState extends CustomState<ConversationListFAB, void, C
   @override
   void dispose() {
     controller.materialScrollController.removeListener(_handleMaterialScroll);
-    _avatarOnlySubscription.cancel();
+    _avatarOnlySubscription?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_list/widgets/tile/conversation_tile.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/conversation_tile.dart
@@ -220,7 +220,7 @@ class ConversationTile extends CustomStateful<ConversationTileController> {
 
 class _ConversationTileState extends CustomState<ConversationTile, void, ConversationTileController> with AutomaticKeepAliveClientMixin {
   ConversationListController get listController => controller.listController;
-  late final StreamSubscription _highlightSubscription;
+  StreamSubscription? _highlightSubscription;
 
   @override
   bool get wantKeepAlive => true;
@@ -252,7 +252,7 @@ class _ConversationTileState extends CustomState<ConversationTile, void, Convers
 
   @override
   void dispose() {
-    _highlightSubscription.cancel();
+    _highlightSubscription?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_list/widgets/tile/conversation_tile.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/conversation_tile.dart
@@ -220,6 +220,7 @@ class ConversationTile extends CustomStateful<ConversationTileController> {
 
 class _ConversationTileState extends CustomState<ConversationTile, void, ConversationTileController> with AutomaticKeepAliveClientMixin {
   ConversationListController get listController => controller.listController;
+  late final StreamSubscription _highlightSubscription;
 
   @override
   bool get wantKeepAlive => true;
@@ -237,7 +238,8 @@ class _ConversationTileState extends CustomState<ConversationTile, void, Convers
           cm.activeChat?.chat.guid == controller.chat.guid;
     }
 
-    eventDispatcher.stream.listen((event) {
+    _highlightSubscription = eventDispatcher.stream.listen((event) {
+      if (!mounted) return;
       if (event.item1 == 'update-highlight' && mounted) {
         if ((kIsDesktop || kIsWeb) && event.item2 == controller.chat.guid) {
           controller.shouldHighlight.value = true;
@@ -246,6 +248,12 @@ class _ConversationTileState extends CustomState<ConversationTile, void, Convers
         }
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _highlightSubscription.cancel();
+    super.dispose();
   }
 
   @override
@@ -318,6 +326,7 @@ class ChatTitle extends CustomStateful<ConversationTileController> {
 class _ChatTitleState extends CustomState<ChatTitle, void, ConversationTileController> {
   String title = "Unknown";
   StreamSubscription? sub;
+  StreamSubscription? eventSub;
   String? cachedDisplayName = "";
   List<Handle> cachedParticipants = [];
 
@@ -356,7 +365,8 @@ class _ChatTitleState extends CustomState<ChatTitle, void, ConversationTileContr
         });
       });
       // listen for contacts update (if tile is active, we can update it)
-      eventDispatcher.stream.listen((event) {
+      eventSub = eventDispatcher.stream.listen((event) {
+        if (!mounted) return;
         if (event.item1 != 'update-contacts') return;
         if (event.item2.isNotEmpty) {
           bool changed = false;
@@ -402,7 +412,8 @@ class _ChatTitleState extends CustomState<ChatTitle, void, ConversationTileContr
 
   @override
   void dispose() {
-    if (!kIsWeb) sub?.cancel();
+    sub?.cancel();
+    eventSub?.cancel();
     super.dispose();
   }
 
@@ -441,6 +452,7 @@ class _ChatSubtitleState extends CustomState<ChatSubtitle, void, ConversationTil
   String subtitle = "Unknown";
   String fakeText = faker.lorem.words(1).join(" ");
   StreamSubscription? sub;
+  StreamSubscription? eventSub;
   String? cachedLatestMessageGuid = "";
   DateTime? cachedDateCreated;
   DateTime? cachedDateEdited;
@@ -498,7 +510,8 @@ class _ChatSubtitleState extends CustomState<ChatSubtitle, void, ConversationTil
       });
     } else {
       // listen for contacts update (if tile is active, we can update it)
-      eventDispatcher.stream.listen((event) {
+      eventSub = eventDispatcher.stream.listen((event) {
+        if (!mounted) return;
         if (event.item1 != 'update-contacts') return;
         if (event.item2.isNotEmpty) {
           String newSubtitle = MessageHelper.getNotificationText(controller.chat.latestMessage);
@@ -540,6 +553,7 @@ class _ChatSubtitleState extends CustomState<ChatSubtitle, void, ConversationTil
   @override
   void dispose() {
     sub?.cancel();
+    eventSub?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_list/widgets/tile/cupertino_conversation_tile.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/cupertino_conversation_tile.dart
@@ -182,7 +182,7 @@ class CupertinoTrailing extends CustomStateful<ConversationTileController> {
 
 class _CupertinoTrailingState extends CustomState<CupertinoTrailing, void, ConversationTileController> {
   DateTime? dateCreated;
-  late final StreamSubscription sub;
+  StreamSubscription? sub;
   String? cachedLatestMessageGuid = "";
   Message? cachedLatestMessage;
 
@@ -240,7 +240,7 @@ class _CupertinoTrailingState extends CustomState<CupertinoTrailing, void, Conve
 
   @override
   void dispose() {
-    sub.cancel();
+    sub?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_list/widgets/tile/material_conversation_tile.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/material_conversation_tile.dart
@@ -177,7 +177,7 @@ class MaterialTrailing extends CustomStateful<ConversationTileController> {
 
 class _MaterialTrailingState extends CustomState<MaterialTrailing, void, ConversationTileController> {
   DateTime? dateCreated;
-  late final StreamSubscription sub;
+  StreamSubscription? sub;
   String? cachedLatestMessageGuid = "";
   Message? cachedLatestMessage;
 
@@ -235,7 +235,7 @@ class _MaterialTrailingState extends CustomState<MaterialTrailing, void, Convers
 
   @override
   void dispose() {
-    sub.cancel();
+    sub?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_list/widgets/tile/pinned_conversation_tile.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/pinned_conversation_tile.dart
@@ -271,7 +271,7 @@ class ChatTitle extends CustomStateful<ConversationTileController> {
 
 class _ChatTitleState extends CustomState<ChatTitle, void, ConversationTileController> {
   String title = "Unknown";
-  late final StreamSubscription sub;
+  StreamSubscription? sub;
   String? cachedDisplayName = "";
   List<Handle> cachedParticipants = [];
 
@@ -331,7 +331,7 @@ class _ChatTitleState extends CustomState<ChatTitle, void, ConversationTileContr
 
   @override
   void dispose() {
-    sub.cancel();
+    sub?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_list/widgets/tile/pinned_conversation_tile.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/pinned_conversation_tile.dart
@@ -39,6 +39,7 @@ class PinnedConversationTile extends CustomStateful<ConversationTileController> 
 class _PinnedConversationTileState extends CustomState<PinnedConversationTile, void, ConversationTileController> {
   ConversationListController get listController => controller.listController;
   Offset? longPressPosition;
+  late final StreamSubscription _highlightSubscription;
 
   @override
   void initState() {
@@ -53,7 +54,8 @@ class _PinnedConversationTileState extends CustomState<PinnedConversationTile, v
       controller.shouldHighlight.value = cm.activeChat?.chat.guid == controller.chat.guid;
     }
 
-    eventDispatcher.stream.listen((event) {
+    _highlightSubscription = eventDispatcher.stream.listen((event) {
+      if (!mounted) return;
       if (event.item1 == 'update-highlight' && mounted) {
         if ((kIsDesktop || kIsWeb) && event.item2 == controller.chat.guid) {
           controller.shouldHighlight.value = true;
@@ -62,6 +64,12 @@ class _PinnedConversationTileState extends CustomState<PinnedConversationTile, v
         }
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _highlightSubscription.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/app/layouts/conversation_list/widgets/tile/pinned_conversation_tile.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/pinned_conversation_tile.dart
@@ -39,7 +39,7 @@ class PinnedConversationTile extends CustomStateful<ConversationTileController> 
 class _PinnedConversationTileState extends CustomState<PinnedConversationTile, void, ConversationTileController> {
   ConversationListController get listController => controller.listController;
   Offset? longPressPosition;
-  late final StreamSubscription _highlightSubscription;
+  StreamSubscription? _highlightSubscription;
 
   @override
   void initState() {
@@ -68,7 +68,7 @@ class _PinnedConversationTileState extends CustomState<PinnedConversationTile, v
 
   @override
   void dispose() {
-    _highlightSubscription.cancel();
+    _highlightSubscription?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_list/widgets/tile/pinned_tile_text_bubble.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/pinned_tile_text_bubble.dart
@@ -32,7 +32,7 @@ class PinnedTileTextBubbleState extends CustomState<PinnedTileTextBubble, void, 
   Message? lastMessage;
   String subtitle = "Unknown";
   String fakeText = faker.lorem.words(1).join(" ");
-  late final StreamSubscription sub;
+  StreamSubscription? sub;
   String? cachedLatestMessageGuid = "";
   DateTime? cachedDateCreated;
 
@@ -102,7 +102,7 @@ class PinnedTileTextBubbleState extends CustomState<PinnedTileTextBubble, void, 
 
   @override
   void dispose() {
-    sub.cancel();
+    sub?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_list/widgets/tile/samsung_conversation_tile.dart
+++ b/lib/app/layouts/conversation_list/widgets/tile/samsung_conversation_tile.dart
@@ -147,7 +147,7 @@ class SamsungTrailing extends CustomStateful<ConversationTileController> {
 
 class _SamsungTrailingState extends CustomState<SamsungTrailing, void, ConversationTileController> {
   DateTime? dateCreated;
-  late final StreamSubscription sub;
+  StreamSubscription? sub;
   String? cachedLatestMessageGuid = "";
   Message? cachedLatestMessage;
 
@@ -205,7 +205,7 @@ class _SamsungTrailingState extends CustomState<SamsungTrailing, void, Conversat
 
   @override
   void dispose() {
-    sub.cancel();
+    sub?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_view/pages/conversation_view.dart
+++ b/lib/app/layouts/conversation_view/pages/conversation_view.dart
@@ -49,6 +49,8 @@ class ConversationViewState extends OptimizedState<ConversationView> {
     cm.activeChat!.controller = controller;
     Logger.debug("Conversation View initialized for ${chat.guid}");
 
+    controller.updatePoster();
+
     if (widget.onInit != null) {
       Future.delayed(Duration.zero, widget.onInit!);
     }

--- a/lib/app/layouts/conversation_view/pages/messages_view.dart
+++ b/lib/app/layouts/conversation_view/pages/messages_view.dart
@@ -61,7 +61,7 @@ class MessagesViewState extends OptimizedState<MessagesView> {
   final RxBool latestMessageDeliveredState = false.obs;
   final RxBool jumpingToOldestUnread = false.obs;
   final Map<String, FocusNode> messageFocusNodes = {};
-  late final StreamSubscription _eventSubscription;
+  StreamSubscription? _eventSubscription;
 
   ConversationViewController get controller => widget.controller;
 
@@ -203,7 +203,7 @@ class MessagesViewState extends OptimizedState<MessagesView> {
 
   @override
   void dispose() {
-    _eventSubscription.cancel();
+    _eventSubscription?.cancel();
     if (!kIsWeb && !kIsDesktop) smartReply.close();
     if (_messages.isNotEmpty) {
       chat.lastReadMessageGuid = _messages.first.guid;

--- a/lib/app/layouts/conversation_view/pages/messages_view.dart
+++ b/lib/app/layouts/conversation_view/pages/messages_view.dart
@@ -61,6 +61,7 @@ class MessagesViewState extends OptimizedState<MessagesView> {
   final RxBool latestMessageDeliveredState = false.obs;
   final RxBool jumpingToOldestUnread = false.obs;
   final Map<String, FocusNode> messageFocusNodes = {};
+  late final StreamSubscription _eventSubscription;
 
   ConversationViewController get controller => widget.controller;
 
@@ -135,7 +136,8 @@ class MessagesViewState extends OptimizedState<MessagesView> {
   void initState() {
     super.initState();
 
-    eventDispatcher.stream.listen((e) async {
+    _eventSubscription = eventDispatcher.stream.listen((e) async {
+      if (!mounted) return;
       if (e.item1 == "refresh-messagebloc" && e.item2 == chat.guid) {
         // Clear state items
         noMoreMessages = false;
@@ -200,9 +202,12 @@ class MessagesViewState extends OptimizedState<MessagesView> {
 
   @override
   void dispose() {
+    _eventSubscription.cancel();
     if (!kIsWeb && !kIsDesktop) smartReply.close();
-    chat.lastReadMessageGuid = _messages.first.guid;
-    chat.save(updateLastReadMessageGuid: true);
+    if (_messages.isNotEmpty) {
+      chat.lastReadMessageGuid = _messages.first.guid;
+      chat.save(updateLastReadMessageGuid: true);
+    }
     messageService.close(force: widget.customService != null);
     if (controller.bottomMessageFocusNode != null && messageFocusNodes.containsValue(controller.bottomMessageFocusNode)) {
       controller.bottomMessageFocusNode = null;

--- a/lib/app/layouts/conversation_view/pages/messages_view.dart
+++ b/lib/app/layouts/conversation_view/pages/messages_view.dart
@@ -141,6 +141,7 @@ class MessagesViewState extends OptimizedState<MessagesView> {
       if (e.item1 == "refresh-messagebloc" && e.item2 == chat.guid) {
         // Clear state items
         noMoreMessages = false;
+        fetching = false;
         _messages = [];
         // Reload the state after refreshing
         messageService.reload();
@@ -293,28 +294,35 @@ class MessagesViewState extends OptimizedState<MessagesView> {
     if (noMoreMessages || fetching) return;
     fetching = true;
 
-    // Start loading the next chunk of messages
-    noMoreMessages = !(await messageService.loadChunk(_messages.length, controller, limit: limit).catchError((e, stack) {
-      Logger.error("Failed to fetch message chunk!", error: e, trace: stack);
-      return true;
-    }));
+    try {
+      // Start loading the next chunk of messages
+      noMoreMessages = !(await messageService.loadChunk(_messages.length, controller, limit: limit).catchError((e, stack) {
+        Logger.error("Failed to fetch message chunk!", error: e, trace: stack);
+        return true;
+      }));
 
-    if (noMoreMessages) return setState(() {});
-
-    final oldLength = _messages.length;
-    _messages = messageService.struct.messages;
-    _messages.sort(Message.sort);
-    fetching = false;
-    _messages.sublist(max(oldLength - 1, 0)).forEachIndexed((i, m) {
       if (!mounted) return;
-      final c = mwc(m);
-      c.cvController = controller;
-      listKey.currentState!.insertItem(i, duration: const Duration(milliseconds: 0));
-    });
-    _syncBottomMessageFocusNode();
-    // should only happen when a reaction is the most recent message
-    if (oldLength == 0) {
-      setState(() {});
+
+      if (noMoreMessages) {
+        setState(() {});
+        return;
+      }
+
+      final oldLength = _messages.length;
+      _messages = messageService.struct.messages;
+      _messages.sort(Message.sort);
+      _messages.sublist(max(oldLength - 1, 0)).forEachIndexed((i, m) {
+        final c = mwc(m);
+        c.cvController = controller;
+        listKey.currentState!.insertItem(i, duration: const Duration(milliseconds: 0));
+      });
+      _syncBottomMessageFocusNode();
+      // should only happen when a reaction is the most recent message
+      if (oldLength == 0) {
+        setState(() {});
+      }
+    } finally {
+      fetching = false;
     }
   }
 

--- a/lib/app/layouts/conversation_view/widgets/effects/screen_effects_widget.dart
+++ b/lib/app/layouts/conversation_view/widgets/effects/screen_effects_widget.dart
@@ -37,7 +37,7 @@ class _ScreenEffectsWidgetState extends OptimizedState<ScreenEffectsWidget> with
   late final SpotlightController spotlightController;
   late final LaserController laserController;
   String screenSelected = "";
-  late final StreamSubscription _effectSubscription;
+  StreamSubscription? _effectSubscription;
 
   @override
   void initState() {
@@ -130,7 +130,7 @@ class _ScreenEffectsWidgetState extends OptimizedState<ScreenEffectsWidget> with
 
   @override
   void dispose() {
-    _effectSubscription.cancel();
+    _effectSubscription?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_view/widgets/effects/screen_effects_widget.dart
+++ b/lib/app/layouts/conversation_view/widgets/effects/screen_effects_widget.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:bluebubbles/app/animations/balloon_classes.dart';
@@ -36,6 +37,7 @@ class _ScreenEffectsWidgetState extends OptimizedState<ScreenEffectsWidget> with
   late final SpotlightController spotlightController;
   late final LaserController laserController;
   String screenSelected = "";
+  late final StreamSubscription _effectSubscription;
 
   @override
   void initState() {
@@ -51,7 +53,7 @@ class _ScreenEffectsWidgetState extends OptimizedState<ScreenEffectsWidget> with
       laserController = LaserController(vsync: this, windowSize: Size(ns.width(context), context.height));
     });
 
-    eventDispatcher.stream.listen((event) async {
+    _effectSubscription = eventDispatcher.stream.listen((event) async {
       if (event.item1 == 'play-effect' && mounted && screenSelected.isEmpty) {
         setState(() {
           screenSelected = event.item2['type'];
@@ -124,6 +126,12 @@ class _ScreenEffectsWidgetState extends OptimizedState<ScreenEffectsWidget> with
         }
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _effectSubscription.cancel();
+    super.dispose();
   }
 
 

--- a/lib/app/layouts/conversation_view/widgets/effects/screen_effects_widget.dart
+++ b/lib/app/layouts/conversation_view/widgets/effects/screen_effects_widget.dart
@@ -38,23 +38,25 @@ class _ScreenEffectsWidgetState extends OptimizedState<ScreenEffectsWidget> with
   late final LaserController laserController;
   String screenSelected = "";
   StreamSubscription? _effectSubscription;
+  bool _controllersInitialized = false;
+  int _effectGeneration = 0;
+
+  bool _isEffectActive(int generation) => mounted && generation == _effectGeneration;
+
+  void _clearEffect(int generation) {
+    if (!_isEffectActive(generation)) return;
+    setState(() {
+      screenSelected = "";
+    });
+  }
 
   @override
   void initState() {
     super.initState();
 
-    updateObx(() {
-      fireworkController = FireworkController(vsync: this, windowSize: Size(ns.width(context), context.height));
-      celebrationController = CelebrationController(vsync: this, windowSize: Size(ns.width(context), context.height));
-      confettiController = ConfettiController(duration: const Duration(seconds: 1));
-      balloonController = BalloonController(vsync: this, windowSize: Size(ns.width(context), context.height));
-      loveController = LoveController(vsync: this, windowSize: Size(ns.width(context), context.height));
-      spotlightController = SpotlightController(vsync: this, windowSize: Size(ns.width(context), context.height));
-      laserController = LaserController(vsync: this, windowSize: Size(ns.width(context), context.height));
-    });
-
     _effectSubscription = eventDispatcher.stream.listen((event) async {
-      if (event.item1 == 'play-effect' && mounted && screenSelected.isEmpty) {
+      if (event.item1 == 'play-effect' && mounted && _controllersInitialized && screenSelected.isEmpty) {
+        final generation = ++_effectGeneration;
         setState(() {
           screenSelected = event.item2['type'];
         });
@@ -63,74 +65,101 @@ class _ScreenEffectsWidgetState extends OptimizedState<ScreenEffectsWidget> with
           fireworkController.windowSize = Size(ns.width(context), context.height);
           fireworkController.start();
           await Future.delayed(const Duration(seconds: 1));
+          if (!_isEffectActive(generation)) return;
           fireworkController.stop(onStop: () {
-            setState(() {
-              screenSelected = "";
-            });
+            _clearEffect(generation);
           });
         } else if (screenSelected == "celebration" && !celebrationController.isPlaying) {
           celebrationController.windowSize = Size(ns.width(context), context.height);
           celebrationController.start();
           await Future.delayed(const Duration(seconds: 1));
+          if (!_isEffectActive(generation)) return;
           celebrationController.stop(onStop: () {
-            setState(() {
-              screenSelected = "";
-            });
+            _clearEffect(generation);
           });
         } else if (screenSelected == "balloons" && !balloonController.isPlaying) {
           balloonController.windowSize = Size(ns.width(context), context.height);
           balloonController.start();
           await Future.delayed(const Duration(seconds: 1));
+          if (!_isEffectActive(generation)) return;
           balloonController.stop(onStop: () {
-            setState(() {
-              screenSelected = "";
-            });
+            _clearEffect(generation);
           });
         } else if (screenSelected == "love" && !loveController.isPlaying) {
           if (rect != null) {
             loveController.windowSize = Size(ns.width(context), context.height);
             loveController.start(Point((rect!.left + rect!.right) / 2, (rect!.top + rect!.bottom) / 2));
             await Future.delayed(const Duration(seconds: 1));
+            if (!_isEffectActive(generation)) return;
             loveController.stop(onStop: () {
-              setState(() {
-                screenSelected = "";
-              });
+              _clearEffect(generation);
             });
+          } else {
+            _clearEffect(generation);
           }
         } else if (screenSelected == "spotlight" && !spotlightController.isPlaying) {
           if (rect != null) {
             spotlightController.windowSize = Size(ns.width(context), context.height);
             spotlightController.start(rect!);
             await Future.delayed(const Duration(seconds: 1));
+            if (!_isEffectActive(generation)) return;
             spotlightController.stop(onStop: () {
-              setState(() {
-                screenSelected = "";
-              });
+              _clearEffect(generation);
             });
+          } else {
+            _clearEffect(generation);
           }
         } else if (screenSelected == "lasers" && !laserController.isPlaying) {
           if (rect != null) {
             laserController.windowSize = Size(ns.width(context), context.height);
             laserController.start(rect!);
             await Future.delayed(const Duration(seconds: 1));
+            if (!_isEffectActive(generation)) return;
             laserController.stop(onStop: () {
-              setState(() {
-                screenSelected = "";
-              });
+              _clearEffect(generation);
             });
+          } else {
+            _clearEffect(generation);
           }
         } else if (screenSelected == "confetti") {
           confettiController.play();
           await Future.delayed(const Duration(seconds: 1));
-          screenSelected = "";
+          _clearEffect(generation);
+        } else {
+          _clearEffect(generation);
         }
       }
     });
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_controllersInitialized) return;
+    final windowSize = Size(ns.width(context), context.height);
+    fireworkController = FireworkController(vsync: this, windowSize: windowSize);
+    celebrationController = CelebrationController(vsync: this, windowSize: windowSize);
+    confettiController = ConfettiController(duration: const Duration(seconds: 1));
+    balloonController = BalloonController(vsync: this, windowSize: windowSize);
+    loveController = LoveController(vsync: this, windowSize: windowSize);
+    spotlightController = SpotlightController(vsync: this, windowSize: windowSize);
+    laserController = LaserController(vsync: this, windowSize: windowSize);
+    _controllersInitialized = true;
+  }
+
+  @override
   void dispose() {
+    _effectGeneration++;
     _effectSubscription?.cancel();
+    if (_controllersInitialized) {
+      fireworkController.dispose();
+      celebrationController.dispose();
+      confettiController.dispose();
+      balloonController.dispose();
+      loveController.dispose();
+      spotlightController.dispose();
+      laserController.dispose();
+    }
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_view/widgets/header/cupertino_header.dart
+++ b/lib/app/layouts/conversation_view/widgets/header/cupertino_header.dart
@@ -448,7 +448,7 @@ class _ChatIconAndTitle extends CustomStateful<ConversationViewController> {
 
 class _ChatIconAndTitleState extends CustomState<_ChatIconAndTitle, void, ConversationViewController> {
   String title = "Unknown";
-  late final StreamSubscription sub;
+  StreamSubscription? sub;
   String? cachedDisplayName = "";
   List<Handle> cachedParticipants = [];
   late String cachedGuid;
@@ -523,7 +523,7 @@ class _ChatIconAndTitleState extends CustomState<_ChatIconAndTitle, void, Conver
 
   @override
   void dispose() {
-    sub.cancel();
+    sub?.cancel();
     sub2.cancel();
     super.dispose();
   }

--- a/lib/app/layouts/conversation_view/widgets/header/material_header.dart
+++ b/lib/app/layouts/conversation_view/widgets/header/material_header.dart
@@ -421,7 +421,7 @@ class _ChatIconAndTitle extends CustomStateful<ConversationViewController> {
 
 class _ChatIconAndTitleState extends CustomState<_ChatIconAndTitle, void, ConversationViewController> {
   String title = "Unknown";
-  late final StreamSubscription sub;
+  StreamSubscription? sub;
   String? cachedDisplayName = "";
   List<Handle> cachedParticipants = [];
 
@@ -491,7 +491,7 @@ class _ChatIconAndTitleState extends CustomState<_ChatIconAndTitle, void, Conver
 
   @override
   void dispose() {
-    sub.cancel();
+    sub?.cancel();
     sub2.cancel();
     super.dispose();
   }

--- a/lib/app/layouts/conversation_view/widgets/message/attachment/attachment_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/attachment_holder.dart
@@ -44,12 +44,14 @@ class _AttachmentHolderState extends CustomState<AttachmentHolder, void, Message
   String? get audioTranscript => getAudioTranscriptsFromAttributedBody(message.attributedBody)[part.part];
   late dynamic content;
   late bool selected = controller.cvController?.isSelected(message.guid!) ?? false;
+  Worker? _selectionWorker;
 
   @override
   void initState() {
     forceDelete = false;
     if (controller.cvController != null && !iOS) {
-      ever<List<Message>>(controller.cvController!.selected, (event) {
+      _selectionWorker = ever<List<Message>>(controller.cvController!.selected, (event) {
+        if (!mounted) return;
         if (controller.cvController!.isSelected(message.guid!) && !selected) {
           setState(() {
             selected = true;
@@ -65,6 +67,11 @@ class _AttachmentHolderState extends CustomState<AttachmentHolder, void, Message
     updateContent();
   }
 
+  @override
+  void dispose() {
+    _selectionWorker?.dispose();
+    super.dispose();
+  }
 
   void updateContent() async {
     try {

--- a/lib/app/layouts/conversation_view/widgets/message/interactive/interactive_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/interactive/interactive_holder.dart
@@ -43,12 +43,14 @@ class _InteractiveHolderState extends CustomState<InteractiveHolder, void, Messa
 
   bool hasImage = false;
   Uint8List? appIcon;
+  Worker? _selectionWorker;
 
   @override
   void initState() {
     forceDelete = false;
     if (controller.cvController != null && !iOS) {
-      ever<List<Message>>(controller.cvController!.selected, (event) {
+      _selectionWorker = ever<List<Message>>(controller.cvController!.selected, (event) {
+        if (!mounted) return;
         if (controller.cvController!.isSelected(message.guid!) && !selected) {
           setState(() {
             selected = true;
@@ -84,6 +86,12 @@ class _InteractiveHolderState extends CustomState<InteractiveHolder, void, Messa
     });
 
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _selectionWorker?.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:bluebubbles/app/components/custom/custom_bouncing_scroll_physics.dart';
@@ -84,6 +85,7 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
   List<GlobalKey> keys = [];
   bool gaveHapticFeedback = false;
   final RxBool tapped = false.obs;
+  late final StreamSubscription _avatarRefreshSubscription;
 
   @override
   void initState() {
@@ -105,12 +107,19 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
       keys = List.generate(messageParts.length, (_) => GlobalKey());
     }
 
-    eventDispatcher.stream.listen((event) {
+    _avatarRefreshSubscription = eventDispatcher.stream.listen((event) {
+      if (!mounted) return;
       if (event.item1 != 'refresh-avatar') return;
       if (event.item2[0] != message.handle?.address) return;
       message.handle?.color = event.item2[1];
       setState(() {});
     });
+  }
+
+  @override
+  void dispose() {
+    _avatarRefreshSubscription.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -85,7 +85,7 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
   List<GlobalKey> keys = [];
   bool gaveHapticFeedback = false;
   final RxBool tapped = false.obs;
-  late final StreamSubscription _avatarRefreshSubscription;
+  StreamSubscription? _avatarRefreshSubscription;
 
   @override
   void initState() {
@@ -118,7 +118,7 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
 
   @override
   void dispose() {
-    _avatarRefreshSubscription.cancel();
+    _avatarRefreshSubscription?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_view/widgets/message/misc/bubble_effects.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/bubble_effects.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 import 'dart:ui';
 
@@ -41,12 +42,14 @@ class _BubbleEffectsState extends OptimizedState<BubbleEffects> {
   late MovieTween tween;
   Control controller = Control.stop;
   Size size = Size.zero;
+  late final StreamSubscription _effectSubscription;
 
   @override
   void initState() {
     getTween();
 
-    eventDispatcher.stream.listen((event) async {
+    _effectSubscription = eventDispatcher.stream.listen((event) {
+      if (!mounted) return;
       if (event.item1 == 'play-bubble-effect' && event.item2 == '${widget.part}/${widget.message.guid}') {
         size = widget.globalKey?.currentContext?.size ?? Size.zero;
         setState(() {
@@ -56,6 +59,12 @@ class _BubbleEffectsState extends OptimizedState<BubbleEffects> {
     });
 
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _effectSubscription.cancel();
+    super.dispose();
   }
 
   void getTween() {

--- a/lib/app/layouts/conversation_view/widgets/message/misc/bubble_effects.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/misc/bubble_effects.dart
@@ -42,7 +42,7 @@ class _BubbleEffectsState extends OptimizedState<BubbleEffects> {
   late MovieTween tween;
   Control controller = Control.stop;
   Size size = Size.zero;
-  late final StreamSubscription _effectSubscription;
+  StreamSubscription? _effectSubscription;
 
   @override
   void initState() {
@@ -63,7 +63,7 @@ class _BubbleEffectsState extends OptimizedState<BubbleEffects> {
 
   @override
   void dispose() {
-    _effectSubscription.cancel();
+    _effectSubscription?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_view/widgets/message/text/text_bubble.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/text/text_bubble.dart
@@ -37,7 +37,7 @@ class _TextBubbleState extends CustomState<TextBubble, void, MessageWidgetContro
   late MovieTween tween;
   Control anim = Control.stop;
   late bool selected = controller.cvController?.isSelected(message.guid!) ?? false;
-  late final StreamSubscription _effectSubscription;
+  StreamSubscription? _effectSubscription;
   Worker? _selectionWorker;
 
   @override
@@ -83,7 +83,7 @@ class _TextBubbleState extends CustomState<TextBubble, void, MessageWidgetContro
 
   @override
   void dispose() {
-    _effectSubscription.cancel();
+    _effectSubscription?.cancel();
     _selectionWorker?.dispose();
     super.dispose();
   }

--- a/lib/app/layouts/conversation_view/widgets/message/text/text_bubble.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/text/text_bubble.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
@@ -36,6 +37,8 @@ class _TextBubbleState extends CustomState<TextBubble, void, MessageWidgetContro
   late MovieTween tween;
   Control anim = Control.stop;
   late bool selected = controller.cvController?.isSelected(message.guid!) ?? false;
+  late final StreamSubscription _effectSubscription;
+  Worker? _selectionWorker;
 
   @override
   void initState() {
@@ -53,7 +56,8 @@ class _TextBubbleState extends CustomState<TextBubble, void, MessageWidgetContro
         ..scene(begin: Duration.zero, duration: const Duration(milliseconds: 500), curve: Curves.easeInOut)
             .tween("size", 1.0.tweenTo(1.0));
     }
-    eventDispatcher.stream.listen((event) async {
+    _effectSubscription = eventDispatcher.stream.listen((event) {
+      if (!mounted) return;
       if (event.item1 == 'play-bubble-effect' && event.item2 == '${part.part}/${message.guid}' && effect == MessageEffect.gentle) {
         setState(() {
           anim = Control.playFromStart;
@@ -61,7 +65,8 @@ class _TextBubbleState extends CustomState<TextBubble, void, MessageWidgetContro
       }
     });
     if (controller.cvController != null && !iOS) {
-      ever<List<Message>>(controller.cvController!.selected, (event) {
+      _selectionWorker = ever<List<Message>>(controller.cvController!.selected, (event) {
+        if (!mounted) return;
         if (controller.cvController!.isSelected(message.guid!) && !selected) {
           setState(() {
             selected = true;
@@ -74,6 +79,13 @@ class _TextBubbleState extends CustomState<TextBubble, void, MessageWidgetContro
       });
     }
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _effectSubscription.cancel();
+    _selectionWorker?.dispose();
+    super.dispose();
   }
 
   List<Color> getBubbleColors() {

--- a/lib/app/layouts/conversation_view/widgets/message/timestamp/delivered_indicator.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/timestamp/delivered_indicator.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
 import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/models.dart';
@@ -22,17 +24,25 @@ class DeliveredIndicator extends CustomStateful<MessageWidgetController> {
 class _DeliveredIndicatorState extends CustomState<DeliveredIndicator, void, MessageWidgetController> {
   Message get message => controller.message;
   bool get showAvatar => (controller.cvController?.chat ?? cm.activeChat!.chat).isGroup;
+  late final StreamSubscription _messageUpdateSubscription;
 
   @override
   void initState() {
     forceDelete = false;
     super.initState();
 
-    eventDispatcher.stream.listen((event) {
+    _messageUpdateSubscription = eventDispatcher.stream.listen((event) {
+      if (!mounted) return;
       if (event.item1 == "message-updated-${message.guid}") {
         setState(() {});
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _messageUpdateSubscription.cancel();
+    super.dispose();
   }
 
   bool get shouldShow {

--- a/lib/app/layouts/conversation_view/widgets/message/timestamp/delivered_indicator.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/timestamp/delivered_indicator.dart
@@ -24,7 +24,7 @@ class DeliveredIndicator extends CustomStateful<MessageWidgetController> {
 class _DeliveredIndicatorState extends CustomState<DeliveredIndicator, void, MessageWidgetController> {
   Message get message => controller.message;
   bool get showAvatar => (controller.cvController?.chat ?? cm.activeChat!.chat).isGroup;
-  late final StreamSubscription _messageUpdateSubscription;
+  StreamSubscription? _messageUpdateSubscription;
 
   @override
   void initState() {
@@ -41,7 +41,7 @@ class _DeliveredIndicatorState extends CustomState<DeliveredIndicator, void, Mes
 
   @override
   void dispose() {
-    _messageUpdateSubscription.cancel();
+    _messageUpdateSubscription?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/settings/pages/theming/theming_panel.dart
+++ b/lib/app/layouts/settings/pages/theming/theming_panel.dart
@@ -463,7 +463,7 @@ class _ThemingPanelState extends CustomState<ThemingPanel, void, ThemingPanelCon
                 ),
                 if (!kIsWeb && !kIsDesktop)
                   Obx(() {
-                    if (controller.refreshRates.length > 2) {
+                    if (controller.refreshRates.length > 1) {
                       return SettingsHeader(
                           iosSubtitle: iosSubtitle,
                           materialSubtitle: materialSubtitle,
@@ -474,7 +474,7 @@ class _ThemingPanelState extends CustomState<ThemingPanel, void, ThemingPanelCon
                   }),
                 if (!kIsWeb && !kIsDesktop)
                   Obx(() {
-                    if (controller.refreshRates.length > 2) {
+                    if (controller.refreshRates.length > 1) {
                       return SettingsSection(
                         backgroundColor: tileColor,
                         children: [

--- a/lib/app/wrappers/stateful_boilerplate.dart
+++ b/lib/app/wrappers/stateful_boilerplate.dart
@@ -8,7 +8,7 @@ import 'package:get/get.dart';
 /// [GetxController] with support for optimized state management
 class StatefulController extends GetxController {
   final Map<Object, List<Function>> updateWidgetFunctions = {};
-  late final void Function(VoidCallback) updateObx;
+  late void Function(VoidCallback) updateObx;
 
   void updateWidgets<T>(Object? arg) {
     updateWidgetFunctions[T]?.forEach((e) => e.call(arg));
@@ -50,8 +50,8 @@ abstract class CustomState<T extends CustomStateful, R, S extends StatefulContro
     super.initState();
 
     // set functions in the custom [GetxController]
-    // this if clause allows us to only set the late final variable
-    // when we are sure the controller is a fresh one
+    // Rebind after the last widget using a retained controller is disposed.
+    // Message controllers can outlive lazily recycled list rows.
     if (widget.parentController.updateWidgetFunctions.isEmpty) {
       widget.parentController.updateObx = updateObx;
     }

--- a/lib/app/wrappers/stateful_boilerplate.dart
+++ b/lib/app/wrappers/stateful_boilerplate.dart
@@ -28,6 +28,7 @@ abstract class CustomStateful<T extends StatefulController> extends StatefulWidg
 abstract class CustomState<T extends CustomStateful, R, S extends StatefulController> extends State<T> with ThemeHelpers {
   // completer to check if the page animation is complete
   final animCompleted = Completer<void>();
+  late final void Function(R) _updateWidgetCallback;
 
   @protected
   /// Convenience getter for the [GetxController]
@@ -55,7 +56,8 @@ abstract class CustomState<T extends CustomStateful, R, S extends StatefulContro
       widget.parentController.updateObx = updateObx;
     }
     widget.parentController.updateWidgetFunctions[T] ??= [];
-    widget.parentController.updateWidgetFunctions[T]!.add(updateWidget);
+    _updateWidgetCallback = updateWidget;
+    widget.parentController.updateWidgetFunctions[T]!.add(_updateWidgetCallback);
 
     // complete the completer when we know the page animation has finished
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
@@ -83,6 +85,11 @@ abstract class CustomState<T extends CustomStateful, R, S extends StatefulContro
   /// Force delete the [GetxController] when the page has disposed (unless we
   /// don't want to)
   void dispose() {
+    final callbacks = widget.parentController.updateWidgetFunctions[T];
+    callbacks?.remove(_updateWidgetCallback);
+    if (callbacks?.isEmpty ?? false) {
+      widget.parentController.updateWidgetFunctions.remove(T);
+    }
     if (_forceDelete) Get.delete<S>(tag: _tag);
     super.dispose();
   }

--- a/lib/app/wrappers/tablet_mode_wrapper.dart
+++ b/lib/app/wrappers/tablet_mode_wrapper.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 
 import 'package:bluebubbles/helpers/ui/theme_helpers.dart';
@@ -43,6 +44,8 @@ class _TabletModeWrapperState extends OptimizedState<TabletModeWrapper> {
   late final RxDouble _ratio;
   double? _maxWidth;
   bool? altLayoutCache;
+  late final StreamSubscription _eventSubscription;
+  late final Worker _ratioWorker;
 
   get _width1 => max(min(_ratio * _maxWidth!, widget.maxWidthLeft ?? double.infinity), widget.minWidthLeft ?? double.negativeInfinity);
 
@@ -52,7 +55,8 @@ class _TabletModeWrapperState extends OptimizedState<TabletModeWrapper> {
   void initState() {
     super.initState();
     _ratio = RxDouble((ss.prefs.getDouble('splitRatio') ?? widget.initialRatio).clamp(widget.minRatio, widget.maxRatio));
-    eventDispatcher.stream.listen((event) {
+    _eventSubscription = eventDispatcher.stream.listen((event) {
+      if (!mounted) return;
       if (event.item1 == 'split-refresh') {
         _ratio.value = ss.prefs.getDouble('splitRatio') ?? _ratio.value;
         setState(() {});
@@ -61,10 +65,17 @@ class _TabletModeWrapperState extends OptimizedState<TabletModeWrapper> {
         setState(() {});
       }
     });
-    debounce<double>(_ratio, (val) async {
+    _ratioWorker = debounce<double>(_ratio, (val) async {
       await ss.prefs.setDouble('splitRatio', val);
       eventDispatcher.emit('split-refresh', null);
     });
+  }
+
+  @override
+  void dispose() {
+    _eventSubscription.cancel();
+    _ratioWorker.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/app/wrappers/tablet_mode_wrapper.dart
+++ b/lib/app/wrappers/tablet_mode_wrapper.dart
@@ -44,8 +44,8 @@ class _TabletModeWrapperState extends OptimizedState<TabletModeWrapper> {
   late final RxDouble _ratio;
   double? _maxWidth;
   bool? altLayoutCache;
-  late final StreamSubscription _eventSubscription;
-  late final Worker _ratioWorker;
+  StreamSubscription? _eventSubscription;
+  Worker? _ratioWorker;
 
   get _width1 => max(min(_ratio * _maxWidth!, widget.maxWidthLeft ?? double.infinity), widget.minWidthLeft ?? double.negativeInfinity);
 
@@ -73,8 +73,8 @@ class _TabletModeWrapperState extends OptimizedState<TabletModeWrapper> {
 
   @override
   void dispose() {
-    _eventSubscription.cancel();
-    _ratioWorker.dispose();
+    _eventSubscription?.cancel();
+    _ratioWorker?.dispose();
     super.dispose();
   }
 

--- a/lib/database/io/chat.dart
+++ b/lib/database/io/chat.dart
@@ -390,7 +390,11 @@ class Chat {
   RxDouble sendProgress = 0.0.obs;
 
   void handlesChanged() {
-    var cachedChat = cvc(this).chat;
+    // Group updates can arrive while the app is backgrounded. Do not create a
+    // full conversation controller just to mirror a relation that has no
+    // visible UI; that leaks controller resources and can wake rendering work.
+    if (!Get.isRegistered<ConversationViewController>(tag: guid)) return;
+    var cachedChat = Get.find<ConversationViewController>(tag: guid).chat;
     cachedChat.handles = handles; // someone can't keep their objects in sync...
     cachedChat._participants = [];
   }

--- a/lib/services/rustpush/rustpush_service.dart
+++ b/lib/services/rustpush/rustpush_service.dart
@@ -2828,7 +2828,27 @@ class RustPushService extends GetxService {
   }
 
   List<String> profilesDownloading = [];
-  Future handleSharedProfile(api.ShareProfileMessage shared, String sender, List<Handle> targets) async {
+  final Map<String, DateTime> _profileRetryAfter = {};
+
+  Future<void> handleSharedProfile(api.ShareProfileMessage shared, String sender, List<Handle> targets) async {
+    final profileKey = shared.cloudKitRecordKey;
+    final retryAfter = _profileRetryAfter[profileKey];
+    if (retryAfter != null && retryAfter.isAfter(DateTime.now())) return;
+
+    try {
+      await _handleSharedProfile(shared, sender, targets);
+      _profileRetryAfter.remove(profileKey);
+    } catch (error) {
+      // Shared profile payloads are optional message metadata. A malformed
+      // CloudKit plist must not escape an unawaited profile task and disturb
+      // message delivery or repeatedly consume CPU while the same payload is
+      // replayed.
+      _profileRetryAfter[profileKey] = DateTime.now().add(const Duration(minutes: 10));
+      Logger.warn("Skipping shared profile payload after ${error.runtimeType}");
+    }
+  }
+
+  Future<void> _handleSharedProfile(api.ShareProfileMessage shared, String sender, List<Handle> targets) async {
     var myHandles = await api.getHandles(state: pushService.state!.client);
     if (myHandles.contains(sender)) {
       for (var target in targets) {

--- a/lib/services/rustpush/rustpush_service.dart
+++ b/lib/services/rustpush/rustpush_service.dart
@@ -2829,11 +2829,21 @@ class RustPushService extends GetxService {
 
   List<String> profilesDownloading = [];
   final Map<String, DateTime> _profileRetryAfter = {};
+  static const int _maxProfileRetryEntries = 128;
+
+  void _pruneProfileRetryAfter(DateTime now) {
+    _profileRetryAfter.removeWhere((_, expiry) => !expiry.isAfter(now));
+    while (_profileRetryAfter.length >= _maxProfileRetryEntries) {
+      _profileRetryAfter.remove(_profileRetryAfter.keys.first);
+    }
+  }
 
   Future<void> handleSharedProfile(api.ShareProfileMessage shared, String sender, List<Handle> targets) async {
     final profileKey = shared.cloudKitRecordKey;
+    final now = DateTime.now();
+    _pruneProfileRetryAfter(now);
     final retryAfter = _profileRetryAfter[profileKey];
-    if (retryAfter != null && retryAfter.isAfter(DateTime.now())) return;
+    if (retryAfter != null && retryAfter.isAfter(now)) return;
 
     try {
       await _handleSharedProfile(shared, sender, targets);
@@ -2843,6 +2853,7 @@ class RustPushService extends GetxService {
       // CloudKit plist must not escape an unawaited profile task and disturb
       // message delivery or repeatedly consume CPU while the same payload is
       // replayed.
+      _pruneProfileRetryAfter(DateTime.now());
       _profileRetryAfter[profileKey] = DateTime.now().add(const Duration(minutes: 10));
       Logger.warn("Skipping shared profile payload after ${error.runtimeType}");
     }

--- a/lib/services/ui/chat/conversation_view_controller.dart
+++ b/lib/services/ui/chat/conversation_view_controller.dart
@@ -199,7 +199,6 @@ class ConversationViewController extends StatefulController with GetSingleTicker
         _subjectWasLastFocused = true;
       }
     });
-    updatePoster();
   }
 
   void updatePoster() async {
@@ -301,9 +300,6 @@ class ConversationViewController extends StatefulController with GetSingleTicker
       return;
     }
     imageData[attachment.guid!] = tmpData;
-    try {
-      await precacheImage(MemoryImage(tmpData), queued.item3);
-    } catch (_) {}
     queued.item4.complete(tmpData);
 
     await _processNextImage();

--- a/test/wrappers/stateful_boilerplate_test.dart
+++ b/test/wrappers/stateful_boilerplate_test.dart
@@ -1,0 +1,35 @@
+import 'package:bluebubbles/app/wrappers/stateful_boilerplate.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestController extends StatefulController {}
+
+class _TestWidget extends CustomStateful<_TestController> {
+  const _TestWidget({required super.parentController});
+
+  @override
+  State<_TestWidget> createState() => _TestWidgetState();
+}
+
+class _TestWidgetState extends CustomState<_TestWidget, void, _TestController> {
+  @override
+  void initState() {
+    forceDelete = false;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+void main() {
+  testWidgets('rebinds updates when a retained controller row is remounted', (tester) async {
+    final controller = _TestController();
+
+    await tester.pumpWidget(MaterialApp(home: _TestWidget(parentController: controller)));
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    await tester.pumpWidget(MaterialApp(home: _TestWidget(parentController: controller)));
+
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
Part 2 of 3. This replaces #225, which mixed too many unrelated themes to review. Split into focused PRs so each can be evaluated on its own.

**Series:** [Part 1 - delivery integrity](https://github.com/OpenBubbles/openbubbles-app/pull/226) - [Part 2 - lifecycle leaks](https://github.com/OpenBubbles/openbubbles-app/pull/227) - [Part 3 - reply threads and keyboard](https://github.com/OpenBubbles/openbubbles-app/pull/228)

## What this fixes

Scrolling a long transcript produced gray error blocks where messages should be, and the app leaked subscriptions and animation tickers as rows were recycled.

**Recycled rows crashed on remount.** `updateObx` was a `late final` callback that got re-initialized when a widget was recycled, throwing `LateError` and rendering an error block instead of the message. On a long transcript this cascaded: once one row failed, scrolling produced more. Controller state is now torn down on recycle and re-initialized cleanly on remount, with a regression test that mounts, disposes, and remounts the same controller.

**Subscriptions outlived their widgets.** Event listeners on conversation tiles, message holders, attachment and interactive holders, text bubbles, delivered indicators, and the tablet-mode wrapper were never cancelled. They are now cancelled on dispose.

**Animation tickers were not disposed.** The balloon, celebration, fireworks, laser, love, and spotlight effect classes each leaked their ticker. Screen effects and bubble effects held controllers past their widget's life.

**Partial initialization could be observed.** Widgets could build against half-initialized state during profile and contact hydration. Initialization is now guarded so a partially built widget cannot be rendered.

**Full-resolution images were decoded eagerly.** Conversation view decoded attachments at full resolution before they were needed, spiking memory on image-heavy chats. Decoding is now deferred and size-bounded.

**Group avatars churned background controllers.** Refreshing a group avatar spun up and discarded controllers repeatedly; it now refreshes in place.

**Malformed shared profiles could disturb delivery.** A bad CloudKit profile payload could escape an unawaited task. Those failures are now isolated and rate-limited with a bounded retry map, so a repeatedly replayed bad payload cannot consume CPU.

## Validation

- Tests pass, including a new regression test for the recycled-controller remount path.
- `flutter analyze`: no errors in any file this PR touches. The analyzer reports 31 pre-existing errors in `lib/database/html/`, vendored `rust_builder/cargokit/`, and the `telephony_plus` example, plus two in `test_driver/`; all are unchanged by this PR and present on the base branch.
- Device evidence below was gathered on the combined branch (previously #225), which contained all of these changes together. The split branches have not been separately built into an APK and installed; they are verified here by tests and analysis.
- Exercised on a Pixel 10 Pro: a device log captured before this change showed a repeating cascade of `LateError` render failures while scrolling a long transcript. After the change, the same device and same build type rendered 1,788 frames with 10 janky frames (0.56%), p50 5 ms, p95 6 ms, p99 12 ms, and zero render errors.

## Notes for review

- This PR does not change the `rustpush` submodule pointer.
- It shares three files with Part 1 (`messages_view.dart`, `rustpush_service.dart`, `conversation_tile.dart`) and three with Part 3 (`conversation_view.dart`, `message_holder.dart`, `conversation_view_controller.dart`), but edits different regions of each. Whichever merges first, I will rebase the others.


