### PR TITLE
Load complete reply threads and make keyboard dismissal reliable

### DIFF
--- a/lib/app/layouts/conversation_view/pages/conversation_view.dart
+++ b/lib/app/layouts/conversation_view/pages/conversation_view.dart
@@ -93,6 +93,12 @@ class ConversationViewState extends OptimizedState<ConversationView> {
           canPop: false,
           onPopInvoked: (didPop) async {
             if (didPop) return;
+            if (controller.keyboardOpen ||
+                controller.focusNode.hasFocus ||
+                controller.subjectFocusNode.hasFocus) {
+              controller.dismissKeyboard();
+              return;
+            }
             if (controller.inSelectMode.value) {
               controller.inSelectMode.value = false;
               controller.selected.clear();
@@ -155,10 +161,20 @@ class ConversationViewState extends OptimizedState<ConversationView> {
                             Expanded(
                               child: Stack(
                                 children: [
-                                  MessagesView(
-                                    key: Key(chat.guid),
-                                    customService: widget.customService,
-                                    controller: controller,
+                                  Listener(
+                                    behavior: HitTestBehavior.translucent,
+                                    onPointerDown: (_) {
+                                      if (controller.keyboardOpen ||
+                                          controller.focusNode.hasFocus ||
+                                          controller.subjectFocusNode.hasFocus) {
+                                        controller.dismissKeyboard();
+                                      }
+                                    },
+                                    child: MessagesView(
+                                      key: Key(chat.guid),
+                                      customService: widget.customService,
+                                      controller: controller,
+                                    ),
                                   ),
                                   Align(
                                     alignment: iOS ? Alignment.bottomRight : Alignment.bottomCenter,
@@ -218,8 +234,7 @@ class ConversationViewState extends OptimizedState<ConversationView> {
                                       if (ss.settings.swipeToCloseKeyboard.value &&
                                           details.delta.dy > 0 &&
                                           controller.keyboardOpen) {
-                                        controller.focusNode.unfocus();
-                                        controller.subjectFocusNode.unfocus();
+                                        controller.dismissKeyboard();
                                       } else if (ss.settings.swipeToOpenKeyboard.value &&
                                           details.delta.dy < 0 &&
                                           !controller.keyboardOpen) {

--- a/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/message_holder.dart
@@ -15,6 +15,7 @@ import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/popup/
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/reaction/reaction_holder.dart';
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/reply/reply_bubble.dart';
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/reply/reply_line_painter.dart';
+import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/reply/reply_thread_popup.dart';
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/text/text_bubble.dart';
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/timestamp/delivered_indicator.dart';
 import 'package:bluebubbles/app/layouts/conversation_view/widgets/message/timestamp/message_timestamp.dart';
@@ -182,6 +183,12 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
     Iterable<Message> reactionsForPart(int part) {
       return reactions.where((s) => (s.associatedMessagePart ?? 0) == part);
     }
+    final replyTarget = replyTo;
+    MessageWidgetController? replyController;
+    if (replyTarget?.guid != null) {
+      replyController = getActiveMwc(replyTarget!.guid!) ?? mwc(replyTarget);
+      replyController.cvController ??= widget.cvController;
+    }
     /// Layout tree
     /// - Timestamp
     /// - Stack (see code comment)
@@ -272,12 +279,12 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
                               && olderMessage != null
                               && message.threadOriginatorGuid != null
                               && message.showUpperMessage(olderMessage!)
-                              && replyTo != null
-                              && getActiveMwc(replyTo!.guid!) != null)
+                              && replyTarget != null
+                              && replyController != null)
                             Padding(
-                              padding: EdgeInsets.only(left: (showAvatar || ss.settings.alwaysShowAvatars.value) && replyTo!.isFromMe! ? 35 : 0),
+                              padding: EdgeInsets.only(left: (showAvatar || ss.settings.alwaysShowAvatars.value) && replyTarget.isFromMe! ? 35 : 0),
                               child: DecoratedBox(
-                                decoration: replyTo!.isFromMe == message.isFromMe ? ReplyLineDecoration(
+                                decoration: replyTarget.isFromMe == message.isFromMe ? ReplyLineDecoration(
                                   isFromMe: message.isFromMe!,
                                   color: context.theme.colorScheme.properSurface,
                                   connectUpper: false,
@@ -286,11 +293,11 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
                                 ) : const BoxDecoration(),
                                 child: Container(
                                   width: double.infinity,
-                                  alignment: replyTo!.isFromMe! ? Alignment.centerRight : Alignment.centerLeft,
+                                  alignment: replyTarget.isFromMe! ? Alignment.centerRight : Alignment.centerLeft,
                                   child: ReplyBubble(
-                                    parentController: getActiveMwc(replyTo!.guid!)!,
-                                    part: replyTo!.guid! == message.threadOriginatorGuid ? message.normalizedThreadPart : 0,
-                                    showAvatar: (chat.isGroup || ss.settings.alwaysShowAvatars.value || !iOS) && !replyTo!.isFromMe!,
+                                    parentController: replyController,
+                                    part: replyTarget.guid! == message.threadOriginatorGuid ? message.normalizedThreadPart : 0,
+                                    showAvatar: (chat.isGroup || ss.settings.alwaysShowAvatars.value || !iOS) && !replyTarget.isFromMe!,
                                     cvController: widget.cvController,
                                   ),
                                 ),
@@ -312,8 +319,8 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
                           if (!iOS && index == 0 && !widget.isReplyThread
                               && olderMessage != null
                               && message.threadOriginatorGuid != null
-                              && replyTo != null
-                              && getActiveMwc(replyTo!.guid!) != null)
+                              && replyTarget != null
+                              && replyController != null)
                             Padding(
                               padding: showAvatar || ss.settings.alwaysShowAvatars.value
                                   ? const EdgeInsets.only(left: 45.0, right: 10) : const EdgeInsets.symmetric(horizontal: 10),
@@ -323,10 +330,10 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
                                   border: Border.fromBorderSide(BorderSide(color: context.theme.colorScheme.properSurface)),
                                 ),
                                 child: ReplyBubble(
-                                  parentController: getActiveMwc(replyTo!.guid!)!,
-                                  part: replyTo!.guid! == message.threadOriginatorGuid ? message.normalizedThreadPart : 0,
+                                  parentController: replyController,
+                                  part: replyTarget.guid! == message.threadOriginatorGuid ? message.normalizedThreadPart : 0,
                                   showAvatar: (chat.isGroup || ss.settings.alwaysShowAvatars.value || !iOS)
-                                      && !replyTo!.isFromMe!,
+                                      && !replyTarget.isFromMe!,
                                   cvController: widget.cvController,
                                 ),
                               ),
@@ -369,6 +376,8 @@ class _MessageHolderState extends CustomState<MessageHolder, void, MessageWidget
                                       } else {
                                         widget.cvController.selected.add(message);
                                       }
+                                    } : message.threadOriginatorGuid != null && !widget.isReplyThread ? () {
+                                      showReplyThread(context, message, e, service, widget.cvController);
                                     } : kIsDesktop || kIsWeb || iOS || material ? () => tapped.value = !tapped.value : null,
                                     child: IgnorePointer(
                                       ignoring: widget.cvController.inSelectMode.value,

--- a/lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/reaction/reaction.dart
@@ -12,7 +12,6 @@ import 'package:defer_pointer/defer_pointer.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
 import 'package:universal_io/io.dart';
 
@@ -34,8 +33,7 @@ class ReactionWidget extends StatefulWidget {
 
 class ReactionWidgetState extends OptimizedState<ReactionWidget> {
   late Message reaction = widget.reaction;
-  late final StreamSubscription sub;
-  bool hasStream = false;
+  StreamSubscription? sub;
 
   List<Message>? get reactions => widget.reactions;
   bool get reactionIsFromMe => reaction.isFromMe!;
@@ -70,8 +68,6 @@ class ReactionWidgetState extends OptimizedState<ReactionWidget> {
             getActiveMwc(widget.message!.guid!)?.updateAssociatedMessage(reaction, updateHolder: false);
           }
         });
-
-        hasStream = true;
       } else if (kIsWeb && widget.message != null) {
         sub = WebListeners.messageUpdate.listen((tuple) {
           final _message = tuple.item1;
@@ -125,7 +121,7 @@ class ReactionWidgetState extends OptimizedState<ReactionWidget> {
 
   @override
   void dispose() {
-    if (!kIsWeb && hasStream) sub.cancel();
+    sub?.cancel();
     super.dispose();
   }
 

--- a/lib/app/layouts/conversation_view/widgets/message/reply/reply_thread_popup.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/reply/reply_thread_popup.dart
@@ -5,7 +5,6 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/database.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:collection/collection.dart';
 import 'package:defer_pointer/defer_pointer.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -13,9 +12,36 @@ import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:flutter_acrylic/flutter_acrylic.dart';
 
-void showReplyThread(BuildContext context, Message message, MessagePart part, MessagesService service, ConversationViewController cvController) {
+Future<void> showReplyThread(BuildContext context, Message message, MessagePart part, MessagesService service, ConversationViewController cvController) async {
+  cvController.dismissKeyboard();
   final originatorPart = message.threadOriginatorGuid != null ? message.normalizedThreadPart : part.part;
-  final _messages = service.struct.threads(message.threadOriginatorGuid ?? message.guid!, originatorPart);
+  final originatorGuid = message.threadOriginatorGuid ?? message.guid!;
+  final messagesByGuid = <String, Message>{};
+
+  if (!kIsWeb) {
+    final originator = Message.findOne(guid: originatorGuid);
+    final query = Database.messages.query(Message_.threadOriginatorGuid.equals(originatorGuid)).build();
+    final storedReplies = query.find();
+    query.close();
+
+    for (final stored in [
+      if (originator != null) originator,
+      ...storedReplies,
+    ]) {
+      if (stored.guid == null || stored.associatedMessageGuid != null) continue;
+      if (stored.guid != originatorGuid && stored.normalizedThreadPart != originatorPart) continue;
+      stored.fetchAttachments();
+      stored.fetchAssociatedMessages(service: service);
+      stored.handle = stored.getHandle();
+      messagesByGuid[stored.guid!] = stored;
+    }
+  }
+
+  // Prefer live in-memory messages when both sources contain the same item.
+  for (final live in service.struct.threads(originatorGuid, originatorPart)) {
+    if (live.guid != null) messagesByGuid[live.guid!] = live;
+  }
+  final _messages = messagesByGuid.values.toList();
   _messages.sort((a, b) => Message.sort(a, b, descending: false));
   _buildThreadView(_messages, originatorPart, cvController, context);
 }
@@ -92,39 +118,40 @@ void _buildThreadView(List<Message> _messages, int? originatorPart, Conversation
                           ),
                           Container(
                             child: SafeArea(
-                              child: Padding(
-                                padding: const EdgeInsets.symmetric(vertical: 8.0),
-                                child: Center(
-                                  child: SingleChildScrollView(
-                                    controller: controller,
-                                    child: Column(
-                                      children: _messages.mapIndexed((index, e) => GestureDetector(
-                                        onTap: () {
-                                          Navigator.of(context).pop();
-                                          if (originatorPart == null && ss.settings.skin.value == Skins.iOS) {
-                                            // pop twice to remove convo details page
-                                            Navigator.of(context).pop();
-                                          }
-                                          ms(cvController.chat.guid).jumpToMessage.call(e.guid!);
-                                        },
-                                        child: AbsorbPointer(
-                                          absorbing: true,
-                                          child: Padding(
-                                              padding: const EdgeInsets.only(left: 5.0, right: 5.0),
-                                              child: MessageHolder(
-                                                cvController: cvController,
-                                                message: _messages[index],
-                                                oldMessageGuid: index > 0 ? _messages[index - 1].guid : null,
-                                                newMessageGuid: index < _messages.length - 1 ? _messages[index + 1].guid : null,
-                                                isReplyThread: true,
-                                                replyPart: index == 0 ? originatorPart : null,
-                                              ),
-                                          ),
+                              child: ListView.builder(
+                                controller: controller,
+                                padding: const EdgeInsets.symmetric(vertical: 16),
+                                keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+                                itemCount: _messages.length,
+                                itemBuilder: (context, index) {
+                                  final threadMessage = _messages[index];
+                                  final messageController = getActiveMwc(threadMessage.guid!) ?? mwc(threadMessage);
+                                  messageController.cvController = cvController;
+                                  return GestureDetector(
+                                    onTap: () {
+                                      Navigator.of(context).pop();
+                                      if (originatorPart == null && ss.settings.skin.value == Skins.iOS) {
+                                        // pop twice to remove convo details page
+                                        Navigator.of(context).pop();
+                                      }
+                                      ms(cvController.chat.guid).jumpToMessage.call(threadMessage.guid!);
+                                    },
+                                    child: AbsorbPointer(
+                                      absorbing: true,
+                                      child: Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 5),
+                                        child: MessageHolder(
+                                          cvController: cvController,
+                                          message: threadMessage,
+                                          oldMessageGuid: index > 0 ? _messages[index - 1].guid : null,
+                                          newMessageGuid: index < _messages.length - 1 ? _messages[index + 1].guid : null,
+                                          isReplyThread: true,
+                                          replyPart: index == 0 ? originatorPart : null,
                                         ),
-                                      )).toList(),
+                                      ),
                                     ),
-                                  ),
-                                ),
+                                  );
+                                },
                               ),
                             ),
                           ),

--- a/lib/database/global/chat_messages.dart
+++ b/lib/database/global/chat_messages.dart
@@ -12,9 +12,18 @@ class ChatMessages {
   List<Message> get messages => _messages.values.toList();
   List<Message> get reactions => _reactions.values.toList();
   List<Attachment> get attachments => _attachments.values.toList();
-  List<Message> threads(String originatorGuid, int originatorPart, {bool returnOriginator = true}) =>
-      _threads[originatorGuid]?.values.where((e) =>
-      (e.normalizedThreadPart == originatorPart && e.guid != originatorGuid) || (returnOriginator ? e.guid == originatorGuid : false)).toList() ?? [];
+  List<Message> threads(String originatorGuid, int originatorPart, {bool returnOriginator = true}) {
+    final thread = _threads[originatorGuid];
+    if (returnOriginator && thread?[originatorGuid] == null) {
+      final originator = _messages[originatorGuid];
+      if (originator != null) {
+        addThreadOriginator(originator);
+      }
+    }
+    return _threads[originatorGuid]?.values.where((e) =>
+        (e.normalizedThreadPart == originatorPart && e.guid != originatorGuid) ||
+        (returnOriginator && e.guid == originatorGuid)).toList() ?? [];
+  }
 
   void addMessages(List<Message> __messages) {
     for (Message m in __messages) {
@@ -27,8 +36,13 @@ class ChatMessages {
       }
       if (m.threadOriginatorGuid != null && !m.guid!.startsWith("temp") && m.associatedMessageGuid == null) {
         // add threaded messages
-        _threads[m.threadOriginatorGuid!] ??= {};
-        _threads[m.threadOriginatorGuid]![m.guid!] = m;
+        final originatorGuid = m.threadOriginatorGuid!;
+        _threads[originatorGuid] ??= {};
+        _threads[originatorGuid]![m.guid!] = m;
+        final loadedOriginator = _messages[originatorGuid];
+        if (loadedOriginator != null) {
+          _threads[originatorGuid]![originatorGuid] = loadedOriginator;
+        }
       }
       if (_threads.keys.contains(m.guid)) {
         // add thread 'originator'

--- a/lib/database/html/message.dart
+++ b/lib/database/html/message.dart
@@ -432,7 +432,8 @@ class Message {
     return isFromMe != newerMessage.isFromMe;
   }
 
-  int get normalizedThreadPart => threadOriginatorPart == null ? 0 : int.parse(threadOriginatorPart![0]);
+  int get normalizedThreadPart =>
+      int.tryParse(threadOriginatorPart?.split(':').first ?? '') ?? 0;
 
   bool connectToUpper() => threadOriginatorGuid != null;
 

--- a/lib/database/io/message.dart
+++ b/lib/database/io/message.dart
@@ -1453,7 +1453,8 @@ class Message {
     return "$part:${run.range[0]}:${run.range[1]}";
   }
 
-  int get normalizedThreadPart => threadOriginatorPart == null ? 0 : int.parse(threadOriginatorPart![0]);
+  int get normalizedThreadPart =>
+      int.tryParse(threadOriginatorPart?.split(':').first ?? '') ?? 0;
 
   bool connectToUpper() => threadOriginatorGuid != null;
 

--- a/lib/services/ui/chat/conversation_view_controller.dart
+++ b/lib/services/ui/chat/conversation_view_controller.dart
@@ -11,6 +11,7 @@ import 'package:bluebubbles/services/services.dart';
 import 'package:emojis/emoji.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:get/get.dart';
 import 'package:google_ml_kit/google_ml_kit.dart' hide Message;
@@ -99,6 +100,7 @@ class ConversationViewController extends StatefulController with GetSingleTicker
   bool keyboardOpen = false;
   double _keyboardOffset = 0;
   Timer? _scrollDownDebounce;
+  StreamSubscription<bool>? keyboardVisibilitySubscription;
   Future<void> Function(Tuple7<List<PlatformFile>, AttributedBody, String, String?, int?, String?, PayloadData?>, bool, DateTime?)? sendFunc;
   bool isProcessingImage = false;
 
@@ -158,7 +160,7 @@ class ConversationViewController extends StatefulController with GetSingleTicker
     updateContactInfo();
 
     textController.mentionables = mentionables;
-    KeyboardVisibilityController().onChange.listen((bool visible) async {
+    keyboardVisibilitySubscription = KeyboardVisibilityController().onChange.listen((bool visible) async {
       keyboardOpen = visible;
       if (scrollController.hasClients) {
         _keyboardOffset = scrollController.offset;
@@ -229,7 +231,14 @@ class ConversationViewController extends StatefulController with GetSingleTicker
     scrollController.dispose();
     headerBackFocusNode.dispose();
     shareSubscription?.cancel();
+    keyboardVisibilitySubscription?.cancel();
     super.onClose();
+  }
+
+  void dismissKeyboard() {
+    focusNode.unfocus();
+    subjectFocusNode.unfocus();
+    SystemChannels.textInput.invokeMethod<void>('TextInput.hide');
   }
 
   Future<void> scrollToBottom() async {

--- a/lib/services/ui/message/message_widget_controller.dart
+++ b/lib/services/ui/message/message_widget_controller.dart
@@ -9,10 +9,8 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/database.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
-import 'package:bluebubbles/utils/logger/logger.dart';
 
 MessageWidgetController mwc(Message message) => Get.isRegistered<MessageWidgetController>(tag: message.guid)
     ? Get.find<MessageWidgetController>(tag: message.guid)
@@ -31,7 +29,7 @@ class MessageWidgetController extends StatefulController with GetSingleTickerPro
   String? newMessageGuid;
   ConversationViewController? cvController;
   late final String tag;
-  late final StreamSubscription? sub;
+  StreamSubscription? sub;
   bool built = false;
 
   static const maxBubbleSizeFactor = 0.75;

--- a/lib/services/ui/message/messages_service.dart
+++ b/lib/services/ui/message/messages_service.dart
@@ -182,7 +182,11 @@ class MessagesService extends GetxController {
     for (Message m in _messages.where((e) => e.threadOriginatorGuid != null)) {
       // see if the originator is already loaded
       final guid = m.threadOriginatorGuid!;
-      if (struct.getMessage(guid) != null) continue;
+      final loadedOriginator = struct.getMessage(guid);
+      if (loadedOriginator != null) {
+        struct.addThreadOriginator(loadedOriginator);
+        continue;
+      }
       // if not, fetch local and add to data
       final threadOriginator = Message.findOne(guid: guid);
       if (threadOriginator != null) {

--- a/lib/services/ui/message/messages_service.dart
+++ b/lib/services/ui/message/messages_service.dart
@@ -19,7 +19,7 @@ String? lastReloadedChat() => Get.isRegistered<String>(tag: 'lastReloadedChat') 
 class MessagesService extends GetxController {
   static final Map<String, Size> cachedBubbleSizes = {};
   late Chat chat;
-  late StreamSubscription countSub;
+  StreamSubscription? countSub;
   final ChatMessages struct = ChatMessages();
   late Function(Message) newFunc;
   late Function(Message, {String? oldGuid}) updateFunc;
@@ -85,7 +85,7 @@ class MessagesService extends GetxController {
   @override
   void onClose() {
     if (_init) {
-      countSub.cancel();
+      countSub?.cancel();
     }
     _init = false;
     super.onClose();

--- a/test/helpers/chat_messages_test.dart
+++ b/test/helpers/chat_messages_test.dart
@@ -1,0 +1,70 @@
+import 'package:bluebubbles/database/models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('includes the originator when it is loaded before its replies', () {
+    final messages = ChatMessages();
+    final originator = Message(guid: 'thread-1', text: 'originator');
+    final reply = Message(
+      guid: 'reply-1',
+      text: 'reply',
+      threadOriginatorGuid: 'thread-1',
+      threadOriginatorPart: '0',
+    );
+
+    messages.addMessages([originator, reply]);
+
+    expect(
+      messages.threads('thread-1', 0).map((message) => message.guid),
+      containsAll(['thread-1', 'reply-1']),
+    );
+  });
+
+  test('includes the originator when it is loaded after its replies', () {
+    final messages = ChatMessages();
+    final originator = Message(guid: 'thread-2', text: 'originator');
+    final reply = Message(
+      guid: 'reply-2',
+      text: 'reply',
+      threadOriginatorGuid: 'thread-2',
+      threadOriginatorPart: '0',
+    );
+
+    messages.addMessages([reply, originator]);
+
+    expect(
+      messages.threads('thread-2', 0).map((message) => message.guid),
+      containsAll(['thread-2', 'reply-2']),
+    );
+  });
+
+  test('returns every message in a lengthy reply chain', () {
+    final messages = ChatMessages();
+    final originator = Message(guid: 'thread-long', text: 'originator');
+    final replies = List.generate(
+      100,
+      (index) => Message(
+        guid: 'reply-long-$index',
+        text: 'reply $index',
+        threadOriginatorGuid: 'thread-long',
+        threadOriginatorPart: '0',
+      ),
+    );
+
+    messages.addMessages([originator, ...replies]);
+
+    final thread = messages.threads('thread-long', 0);
+    expect(thread, hasLength(101));
+    expect(thread.map((message) => message.guid).toSet(), hasLength(101));
+  });
+
+  test('keeps multi-digit reply part indexes intact', () {
+    final reply = Message(
+      guid: 'reply-part-12',
+      threadOriginatorGuid: 'thread-multipart',
+      threadOriginatorPart: '12:4:8',
+    );
+
+    expect(reply.normalizedThreadPart, 12);
+  });
+}

--- a/test/services/conversation_view_controller_test.dart
+++ b/test/services/conversation_view_controller_test.dart
@@ -1,0 +1,26 @@
+import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/services/ui/chat/conversation_view_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('dismissKeyboard releases the conversation composer focus', (tester) async {
+    final controller = ConversationViewController(Chat(guid: 'iMessage;-;keyboard-test'));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TextField(focusNode: controller.focusNode),
+        ),
+      ),
+    );
+    controller.focusNode.requestFocus();
+    await tester.pump();
+    expect(controller.focusNode.hasFocus, isTrue);
+
+    controller.dismissKeyboard();
+    await tester.pump();
+
+    expect(controller.focusNode.hasFocus, isFalse);
+  });
+}


### PR DESCRIPTION
Part 3 of 3. This replaces #225, which mixed too many unrelated themes to review. Split into focused PRs so each can be evaluated on its own.

**Series:** [Part 1 - delivery integrity](https://github.com/OpenBubbles/openbubbles-app/pull/226) - [Part 2 - lifecycle leaks](https://github.com/OpenBubbles/openbubbles-app/pull/227) - [Part 3 - reply threads and keyboard](https://github.com/OpenBubbles/openbubbles-app/pull/228)

## What this fixes

**Reply threads opened without their originating message.** Tapping a threaded reply built the thread view from the currently loaded 50-message window and omitted the message being replied to, so a reply appeared with no context. On iOS the equivalent view always shows the originator first. The thread now loads the complete locally stored chain including the originator, in chronological order, and keeps group sender names so you can tell who said what.

Long chains render lazily rather than building every bubble up front, and multi-digit reply part indexes are parsed correctly instead of truncating at the first digit.

**The keyboard was hard to dismiss.** Inside a conversation the only way to lower the keyboard was the Android Back button, and pressing it twice left the chat entirely. Tapping the transcript and swiping down now both dismiss it, while Back keeps its existing two-step behavior. A keyboard-visibility subscription that was never cancelled is now cancelled on dispose.

**Reply navigation could race the widget lifecycle.** Navigating to a replied-to message could run against a controller whose widget had already been torn down. The navigation path now checks lifecycle state before acting, and the reaction widget no longer holds a controller past its widget's life.

## Validation

- 5/5 tests pass, covering originator-loaded-before-replies, originator-loaded-after-replies, long chains, and multi-digit part indexes.
- `flutter analyze`: no errors in any file this PR touches. The analyzer reports 31 pre-existing errors in `lib/database/html/`, vendored `rust_builder/cargokit/`, and the `telephony_plus` example; all are unchanged by this PR and present on the base branch.
- Device evidence below was gathered on the combined branch (previously #225), which contained all of these changes together. The split branches have not been separately built into an APK and installed; they are verified here by tests and analysis.
- Confirmed on a Pixel 10 Pro against a live relay: opening a threaded reply in a group chat shows the originating message with sender names intact, and all three keyboard dismissal paths work.

## Notes for review

- This PR does not change the `rustpush` submodule pointer.
- It shares four files with Part 1 (`chat_messages.dart`, `database/io/message.dart`, `messages_service.dart`, and the `chat_messages` test) and three with Part 2 (`conversation_view.dart`, `message_holder.dart`, `conversation_view_controller.dart`), but edits different regions of each. Whichever merges first, I will rebase the others.
- The recycled-controller fix in Part 2 is what keeps a long thread from rendering error blocks. This PR stands on its own, but the two are better together.


