### PR TITLE
Unblock CI on v2-rustpush: Flutter pin predates the pubspec

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: 3.24.0
 
       - name: Set up Java
         uses: actions/setup-java@v2


### PR DESCRIPTION
## Problem

CI has failed on every `v2-rustpush` run since at least 2026-06-13 — eight consecutive failures. Dependency resolution never completes, so no build has come off this branch in over a month.

I worked the failures one at a time on a fork. There are **four** blockers stacked behind each other. This PR clears three. The fourth lives in another repository and is diagnosed below.

### Blockers 1-3: the pinned Flutter predates the pubspec (fixed here)

`.github/workflows/build.yml` pins `flutter-version: 3.24.0`, which bundles Dart 3.5.0. Three dependencies need newer, and each only becomes visible once the previous one is cleared:

| Dependency | Requires Dart |
| --- | --- |
| `flutter_lints: ^6.0.0` | `^3.8.0` |
| `local_auth: >=3.0.0` | `>=3.9.0` |
| `flutter_local_notifications: ^21.0.0` | `^3.10.0` |

This PR removes the `flutter-version` pin and lets `channel: stable` take the current stable release.

I tried pinning an explicit version first, which would be preferable for reproducibility, but Flutter 3.38.0 ships `Dart 3.10.0-290.4.beta` and a caret range excludes prereleases:

```
The current Dart SDK version is 3.10.0-290.4.beta.
Because flutter_local_notifications 21.0.0 requires SDK version ^3.10.0 ...
flutter_local_notifications ^21.0.0 is forbidden.
```

If you would rather pin an exact version than track stable, I am happy to change it to whichever release you build against locally. I did not want to guess at a patch version I had not verified.

### Blocker 4: telephony_plus pins an older permission_handler (not fixed here)

```
Because every version of telephony_plus from path depends on permission_handler ^11.3.1
and bluebubbles depends on permission_handler ^12.0.1, telephony_plus from path is forbidden.
```

The `telephony_plus` submodule is pinned at `5210e940`, the newest commit on `OpenBubbles/telephony_plus`, and its pubspec still requires `permission_handler: ^11.3.1`. This branch requires `^12.0.1`. No submodule pointer resolves it — the constraint has to be widened in the `telephony_plus` repo, then re-pinned here.

I left that alone since it is your repo and I have not verified `telephony_plus` against `permission_handler` 12. Glad to open a PR there if you confirm the bump is safe.

## Verification

Iterated on a fork of `v2-rustpush` until each error changed:

| Flutter | Result |
| --- | --- |
| 3.24.0 (current) | fails on `flutter_lints` / Dart 3.8 |
| 3.32.0 | installs clean, fails on `local_auth` / Dart 3.9 |
| 3.35.0 | fails on `flutter_local_notifications` / Dart 3.10 |
| 3.38.0 | Dart 3.10.0 **beta**, caret range rejects it |
| stable, unpinned | **full build succeeds** |

With this change plus a temporary local `permission_handler` override to step around blocker 4, [the build completes green and uploads an APK](https://github.com/Xare123/openbubbles-app/actions/runs/30168754768) — the first successful build off this branch since at least 2026-06-13. The stable channel resolved to Flutter 3.44.8.

If you would rather keep an explicit pin for reproducibility, `flutter-version: 3.44.8` is exactly what this verified against and I will happily change it to that instead. I left it unpinned only because that is the form I tested.

To be explicit: **this PR alone does not turn CI green.** It clears the three version blockers and pinpoints the fourth, which needs a change you own.

Failing runs for reference: [28799954525](https://github.com/OpenBubbles/openbubbles-app/actions/runs/28799954525) (2026-07-06), [28458571081](https://github.com/OpenBubbles/openbubbles-app/actions/runs/28458571081), [28393409768](https://github.com/OpenBubbles/openbubbles-app/actions/runs/28393409768), plus five earlier.
