### PR TITLE
Stop logging message composer contents

### DIFF
--- a/lib/app/components/custom_text_editing_controllers.dart
+++ b/lib/app/components/custom_text_editing_controllers.dart
@@ -442,7 +442,6 @@ class MentionTextEditingController extends SpellCheckTextEditingController {
   @override
   void notifyListeners() {
     super.notifyListeners();
-    Logger.info("a $lastText $text");
     if (lastText != text) {
       // something changed, compute deltas
       // use text diff because some keyboards can bump the cursor forward into an existing space when typing a period during an autocorrect.


### PR DESCRIPTION
## Problem
The composer logged the full draft text on every edit, placing message contents in plaintext diagnostic logs.

## Change
Remove the per-keystroke content log. No composer behavior, annotation handling, storage, or sending logic changes.

## Validation
- one-file, one-line deletion
- `git diff --check` passes
- focused analyzer reports only pre-existing warnings in the controller

## Privacy
This reduces sensitive message exposure. It does not add replacement content logging.