### PR TITLE
Keep composer drafts until message queue acceptance

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/send_animation.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/send_animation.dart
@@ -148,7 +148,7 @@ class _SendAnimationState
         ],
       );
       _message.generateTempGuid();
-      outq.queue(OutgoingItem(
+      await outq.queue(OutgoingItem(
         type: QueueType.sendMessage,
         chat: controller.chat,
         message: _message,

--- a/lib/services/ui/chat/conversation_view_controller.dart
+++ b/lib/services/ui/chat/conversation_view_controller.dart
@@ -260,7 +260,11 @@ class ConversationViewController extends StatefulController with GetSingleTicker
   }
 
   Future<void> send(List<PlatformFile> attachments, AttributedBody text, String subject, String? replyGuid, int? replyPart, String? effectId, PayloadData? payload, bool isAudioMessage, DateTime? scheduledDate) async {
-    sendFunc?.call(Tuple7(attachments, text, subject, replyGuid, replyPart, effectId, payload), isAudioMessage, scheduledDate);
+    final callback = sendFunc;
+    if (callback == null) {
+      throw StateError("Conversation send handler is not ready");
+    }
+    await callback(Tuple7(attachments, text, subject, replyGuid, replyPart, effectId, payload), isAudioMessage, scheduledDate);
   }
 
   void queueImage(Tuple4<Attachment, PlatformFile, BuildContext, Completer<Uint8List>> item) {

--- a/test/services/conversation_view_controller_test.dart
+++ b/test/services/conversation_view_controller_test.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:bluebubbles/database/models.dart';
+import 'package:bluebubbles/services/services.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('send waits for the composer handler to finish', () async {
+    final controller =
+        ConversationViewController(Chat(guid: 'iMessage;-;send-await-test'));
+    final handler = Completer<void>();
+    controller.sendFunc = (_, __, ___) => handler.future;
+
+    var completed = false;
+    final sending = controller
+        .send(
+          [],
+          AttributedBody.raw('message'),
+          '',
+          null,
+          null,
+          null,
+          null,
+          false,
+          null,
+        )
+        .then((_) => completed = true);
+
+    await Future<void>.delayed(Duration.zero);
+    expect(completed, isFalse);
+
+    handler.complete();
+    await sending;
+    expect(completed, isTrue);
+  });
+
+  test('send fails when the composer handler is not ready', () async {
+    final controller =
+        ConversationViewController(Chat(guid: 'iMessage;-;send-missing-test'));
+
+    await expectLater(
+      controller.send(
+        [],
+        AttributedBody.raw('message'),
+        '',
+        null,
+        null,
+        null,
+        null,
+        false,
+        null,
+      ),
+      throwsStateError,
+    );
+  });
+}


### PR DESCRIPTION
## Problem
The composer could clear before the asynchronous send handler accepted a message, making a rejected or stalled send appear to lose the draft.

## Change
Await the composer action handler before clearing text and reply state. Failure leaves the draft intact; successful queue acceptance clears it once.

## Validation
Focused Flutter tests pass: 2/2 for handler completion and unavailable-handler failure.

## Non-goals
This does not change URL parsing, transport retry policy, CloudKit, or attachment downloading.