### PR TITLE
Preserve attachment metadata for external opening

### DIFF
--- a/lib/app/layouts/conversation_view/widgets/message/attachment/other_file.dart
+++ b/lib/app/layouts/conversation_view/widgets/message/attachment/other_file.dart
@@ -7,6 +7,7 @@ import 'package:bluebubbles/helpers/helpers.dart';
 import 'package:bluebubbles/database/models.dart';
 import 'package:bluebubbles/services/services.dart';
 import 'package:bluebubbles/utils/share.dart';
+import 'package:bluebubbles/utils/attachment_mime_utils.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -59,7 +60,12 @@ class OtherFile extends StatelessWidget {
           launchUrl(Uri.file(_file.path));
         } else {
           try {
-            final res = await OpenFilex.open("${fs.appDocDir.path}/attachments/${attachment.guid!}/${basename(file.path!)}");
+            final res = await OpenFilex.open(
+              file.path!,
+              type: attachment.mimeType ??
+                  resolveAttachmentMimeType(file.name, file.path) ??
+                  "application/octet-stream",
+            );
             if (res.type == ResultType.noAppToOpen) {
               showSnackbar('Error', "No handler for this file type! Using share menu instead.");
               await Future.delayed(const Duration(seconds: 1));

--- a/lib/utils/attachment_mime_utils.dart
+++ b/lib/utils/attachment_mime_utils.dart
@@ -1,0 +1,5 @@
+import 'package:mime_type/mime_type.dart';
+
+String? resolveAttachmentMimeType(String name, String? path) {
+  return mime(name) ?? (path == null ? null : mime(path));
+}

--- a/test/utils/attachment_mime_utils_test.dart
+++ b/test/utils/attachment_mime_utils_test.dart
@@ -1,0 +1,46 @@
+import 'package:bluebubbles/utils/attachment_mime_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('resolveAttachmentMimeType', () {
+    test('resolves PDF filenames', () {
+      expect(resolveAttachmentMimeType('report.pdf', null), 'application/pdf');
+    });
+
+    test('resolves DOCX filenames', () {
+      expect(
+        resolveAttachmentMimeType('report.docx', null),
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      );
+    });
+
+    test('resolves XLSX filenames', () {
+      expect(
+        resolveAttachmentMimeType('report.xlsx', null),
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      );
+    });
+
+    test('resolves PPTX filenames', () {
+      expect(
+        resolveAttachmentMimeType('report.pptx', null),
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      );
+    });
+
+    test('resolves plain text filenames', () {
+      expect(resolveAttachmentMimeType('notes.txt', null), 'text/plain');
+    });
+
+    test('leaves unknown binary filenames unresolved', () {
+      expect(resolveAttachmentMimeType('payload.unknown', null), isNull);
+    });
+
+    test('falls back to a path extension when the filename has none', () {
+      expect(
+        resolveAttachmentMimeType('document', '/tmp/document.pdf'),
+        'application/pdf',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem
Downloaded PDFs and Office documents could exist locally but fail to open because cache paths lacked the original extension and MIME context.

## Change
Resolve external-open MIME types from the original filename before falling back to the local path, while preserving unknown-file fallback behavior.

## Validation
Focused Flutter tests pass: 7/7 for PDF, DOCX, XLSX, PPTX, text, unknown binary, and local-path fallback.

## Non-goals
This does not change attachment downloading, replacement-download scheduling, retries, or message storage.