### PR TITLE
Modernize Android CI and run the complete Dart suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -31,7 +29,7 @@ jobs:
           flutter-version: 3.24.0
 
       - name: Set up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -63,6 +61,18 @@ jobs:
               cp rustpush/certs/legacy-fairplay/fairplay.pem rustpush/certs/fairplay/$name.pem
               cp rustpush/certs/legacy-fairplay/fairplay.crt rustpush/certs/fairplay/$name.crt
           done
+
+      # Keep the test gate whole rather than maintaining a hand-curated file
+      # list. This upstream base has no test/ directory yet, so the guard is
+      # intentionally a clean no-op until Dart tests are present.
+      - name: Run the complete Dart test suite
+        run: |
+          set -euo pipefail
+          if [ -d test ]; then
+            flutter test
+          else
+            echo "No test/ directory in this upstream base; Dart suite not present."
+          fi
 
       # First run is expected to fail until ffmpeg_kit_flutter_new is fixed.
       - name: Run Build Script


### PR DESCRIPTION
## Problem
The Android workflow uses deprecated `actions/setup-java@v2`, the archived `actions-rs/toolchain`, and has no complete Dart-suite gate.

## Change
Upgrade Java setup to v5, use `dtolnay/rust-toolchain`, retain the dependency-compatible Flutter 3.24.0 pin, and run the complete Dart suite whenever tests are present.

## Validation
- Flutter 3.24.0 dependency resolution passes locally
- Flutter 3.44.8 was tested and intentionally rejected because upstream dependencies do not currently resolve with Dart 3.12
- workflow YAML parsing and `git diff --check` pass

## Scope
Android CI only. No Windows lanes, signing, sampler APK, Cloud Sync, or app behavior changes.